### PR TITLE
HarvestCraft Item ID Fix

### DIFF
--- a/mod_harvestcraft/plants/artichoke_plant.json
+++ b/mod_harvestcraft/plants/artichoke_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Artichoke Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:artichokeseedItem",
+      "item": "harvestcraft:artichokeseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:artichokeItem",
+        "item": "harvestcraft:artichokeitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/artichokeseedItem",
+    "seed_texture": "harvestcraft:items/artichokeseeditem",
     "plant_textures": [
       "harvestcraft:blocks/crops/artichoke_stage_0",
       "harvestcraft:blocks/crops/artichoke_stage_0",

--- a/mod_harvestcraft/plants/asparagus_plant.json
+++ b/mod_harvestcraft/plants/asparagus_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Asparagus Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:asparagusseedItem",
+      "item": "harvestcraft:asparagusseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:asparagusItem",
+        "item": "harvestcraft:asparagusitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/asparagusseedItem",
+    "seed_texture": "harvestcraft:items/asparagusseeditem",
     "plant_textures": [
       "harvestcraft:blocks/crops/asparagus_stage_0",
       "harvestcraft:blocks/crops/asparagus_stage_0",

--- a/mod_harvestcraft/plants/bambooshoot_plant.json
+++ b/mod_harvestcraft/plants/bambooshoot_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Bamboo Shoot Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:bambooshootseedItem",
+      "item": "harvestcraft:bambooshootseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:bambooshootItem",
+        "item": "harvestcraft:bambooshootitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/bambooshootItem",
+    "seed_texture": "harvestcraft:items/bambooshootitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/bambooshoot_stage_0",
       "harvestcraft:blocks/crops/bambooshoot_stage_0",

--- a/mod_harvestcraft/plants/barley_plant.json
+++ b/mod_harvestcraft/plants/barley_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Barley Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:barleyseedItem",
+      "item": "harvestcraft:barleyseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:barleyItem",
+        "item": "harvestcraft:barleyitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/barleyItem",
+    "seed_texture": "harvestcraft:items/barleyitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/barley_stage_0",
       "harvestcraft:blocks/crops/barley_stage_0",

--- a/mod_harvestcraft/plants/bean_plant.json
+++ b/mod_harvestcraft/plants/bean_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Bean Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:beanseedItem",
+      "item": "harvestcraft:beanseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:beanItem",
+        "item": "harvestcraft:beanitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/beanItem",
+    "seed_texture": "harvestcraft:items/beanitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/bean_stage_0",
       "harvestcraft:blocks/crops/bean_stage_0",

--- a/mod_harvestcraft/plants/beet_plant.json
+++ b/mod_harvestcraft/plants/beet_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Beet Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:beetseedItem",
+      "item": "harvestcraft:beetseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:beetItem",
+        "item": "harvestcraft:beetitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/beetItem",
+    "seed_texture": "harvestcraft:items/beetitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/beet_stage_0",
       "harvestcraft:blocks/crops/beet_stage_0",

--- a/mod_harvestcraft/plants/bellpepper_plant.json
+++ b/mod_harvestcraft/plants/bellpepper_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Bellpepper Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:bellpepperseedItem",
+      "item": "harvestcraft:bellpepperseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:bellpepperItem",
+        "item": "harvestcraft:bellpepperitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/bellpepperItem",
+    "seed_texture": "harvestcraft:items/bellpepperitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/bellpepper_stage_0",
       "harvestcraft:blocks/crops/bellpepper_stage_0",

--- a/mod_harvestcraft/plants/blackberry_plant.json
+++ b/mod_harvestcraft/plants/blackberry_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Blackberry Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:blackberryseedItem",
+      "item": "harvestcraft:blackberryseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:blackberryItem",
+        "item": "harvestcraft:blackberryitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/blackberryItem",
+    "seed_texture": "harvestcraft:items/blackberryitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/blackberry_stage_0",
       "harvestcraft:blocks/crops/blackberry_stage_0",

--- a/mod_harvestcraft/plants/blueberry_plant.json
+++ b/mod_harvestcraft/plants/blueberry_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Blueberry Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:blueberryseedItem",
+      "item": "harvestcraft:blueberryseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:blueberryItem",
+        "item": "harvestcraft:blueberryitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/blueberryItem",
+    "seed_texture": "harvestcraft:items/blueberryitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/blueberry_stage_0",
       "harvestcraft:blocks/crops/blueberry_stage_0",

--- a/mod_harvestcraft/plants/broccoli_plant.json
+++ b/mod_harvestcraft/plants/broccoli_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Broccoli Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:broccoliseedItem",
+      "item": "harvestcraft:broccoliseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:broccoliItem",
+        "item": "harvestcraft:broccoliitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/broccoliItem",
+    "seed_texture": "harvestcraft:items/broccoliitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/broccoli_stage_0",
       "harvestcraft:blocks/crops/broccoli_stage_0",

--- a/mod_harvestcraft/plants/brusselsprout_plant.json
+++ b/mod_harvestcraft/plants/brusselsprout_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Brussel Sprout Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:brusselsproutseedItem",
+      "item": "harvestcraft:brusselsproutseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:brusselsproutItem",
+        "item": "harvestcraft:brusselsproutitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/brusselsproutItem",
+    "seed_texture": "harvestcraft:items/brusselsproutitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/brusselsprout_stage_0",
       "harvestcraft:blocks/crops/brusselsprout_stage_0",

--- a/mod_harvestcraft/plants/cabbage_plant.json
+++ b/mod_harvestcraft/plants/cabbage_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Cabbage Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:cabbageseedItem",
+      "item": "harvestcraft:cabbageseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:cabbageItem",
+        "item": "harvestcraft:cabbageitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/cabbageItem",
+    "seed_texture": "harvestcraft:items/cabbageitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/cabbage_stage_0",
       "harvestcraft:blocks/crops/cabbage_stage_0",

--- a/mod_harvestcraft/plants/cactusfruit_plant.json
+++ b/mod_harvestcraft/plants/cactusfruit_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Cactus Fruit Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:cactusfruitseedItem",
+      "item": "harvestcraft:cactusfruitseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:cactusfruitItem",
+        "item": "harvestcraft:cactusfruititem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/cactusfruitItem",
+    "seed_texture": "harvestcraft:items/cactusfruititem",
     "plant_textures": [
       "harvestcraft:blocks/crops/cactusfruit_stage_0",
       "harvestcraft:blocks/crops/cactusfruit_stage_0",

--- a/mod_harvestcraft/plants/candleberry_plant.json
+++ b/mod_harvestcraft/plants/candleberry_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Candleberry Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:candleberryseedItem",
+      "item": "harvestcraft:candleberryseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:candleberryItem",
+        "item": "harvestcraft:candleberryitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/candleberryItem",
+    "seed_texture": "harvestcraft:items/candleberryitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/candleberry_stage_0",
       "harvestcraft:blocks/crops/candleberry_stage_0",

--- a/mod_harvestcraft/plants/cantaloupe_plant.json
+++ b/mod_harvestcraft/plants/cantaloupe_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Cantaloupe Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:cantaloupeseedItem",
+      "item": "harvestcraft:cantaloupeseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:cantaloupeItem",
+        "item": "harvestcraft:cantaloupeitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/cantaloupeItem",
+    "seed_texture": "harvestcraft:items/cantaloupeitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/cantaloupe_stage_0",
       "harvestcraft:blocks/crops/cantaloupe_stage_0",

--- a/mod_harvestcraft/plants/cauliflower_plant.json
+++ b/mod_harvestcraft/plants/cauliflower_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Cauliflower Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:cauliflowerseedItem",
+      "item": "harvestcraft:cauliflowerseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:cauliflowerItem",
+        "item": "harvestcraft:caulifloweritem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/cauliflowerItem",
+    "seed_texture": "harvestcraft:items/caulifloweritem",
     "plant_textures": [
       "harvestcraft:blocks/crops/cauliflower_stage_0",
       "harvestcraft:blocks/crops/cauliflower_stage_0",

--- a/mod_harvestcraft/plants/celery_plant.json
+++ b/mod_harvestcraft/plants/celery_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Celery Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:celeryseedItem",
+      "item": "harvestcraft:celeryseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:celeryItem",
+        "item": "harvestcraft:celeryitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/celeryItem",
+    "seed_texture": "harvestcraft:items/celeryitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/celery_stage_0",
       "harvestcraft:blocks/crops/celery_stage_0",

--- a/mod_harvestcraft/plants/chilipepper_plant.json
+++ b/mod_harvestcraft/plants/chilipepper_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Chili Pepper Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:chilipepperseedItem",
+      "item": "harvestcraft:chilipepperseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:chilipepperItem",
+        "item": "harvestcraft:chilipepperitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/chilipepperItem",
+    "seed_texture": "harvestcraft:items/chilipepperitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/chilipepper_stage_0",
       "harvestcraft:blocks/crops/chilipepper_stage_0",

--- a/mod_harvestcraft/plants/coffee_plant.json
+++ b/mod_harvestcraft/plants/coffee_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Coffee Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:coffeeseedItem",
+      "item": "harvestcraft:coffeeseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:coffeebeanItem",
+        "item": "harvestcraft:coffeebeanitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/coffeebeanItem",
+    "seed_texture": "harvestcraft:items/coffeebeanitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/coffeebean_stage_0",
       "harvestcraft:blocks/crops/coffeebean_stage_0",

--- a/mod_harvestcraft/plants/corn_plant.json
+++ b/mod_harvestcraft/plants/corn_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Corn Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:cornseedItem",
+      "item": "harvestcraft:cornseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:cornItem",
+        "item": "harvestcraft:cornitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/cornseedItem",
+    "seed_texture": "harvestcraft:items/cornseeditem",
     "plant_textures": [
       "harvestcraft:blocks/crops/corn_stage_0",
       "harvestcraft:blocks/crops/corn_stage_0",

--- a/mod_harvestcraft/plants/cotton_plant.json
+++ b/mod_harvestcraft/plants/cotton_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Cotton Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:cottonseedItem",
+      "item": "harvestcraft:cottonseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:cottonItem",
+        "item": "harvestcraft:cottonitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/cottonItem",
+    "seed_texture": "harvestcraft:items/cottonitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/cotton_stage_0",
       "harvestcraft:blocks/crops/cotton_stage_0",

--- a/mod_harvestcraft/plants/cranberry_plant.json
+++ b/mod_harvestcraft/plants/cranberry_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Cranberry Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:cranberryseedItem",
+      "item": "harvestcraft:cranberryseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:cranberryItem",
+        "item": "harvestcraft:cranberryitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/cranberryItem",
+    "seed_texture": "harvestcraft:items/cranberryitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/cranberry_stage_0",
       "harvestcraft:blocks/crops/cranberry_stage_0",

--- a/mod_harvestcraft/plants/cucumber_plant.json
+++ b/mod_harvestcraft/plants/cucumber_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Cucumber Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:cucumberseedItem",
+      "item": "harvestcraft:cucumberseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:cucumberItem",
+        "item": "harvestcraft:cucumberitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/cucumberItem",
+    "seed_texture": "harvestcraft:items/cucumberitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/cucumber_stage_0",
       "harvestcraft:blocks/crops/cucumber_stage_0",

--- a/mod_harvestcraft/plants/curryleaf_plant.json
+++ b/mod_harvestcraft/plants/curryleaf_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Curryleaf Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:curryleafseedItem",
+      "item": "harvestcraft:curryleafseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:curryleafItem",
+        "item": "harvestcraft:curryleafitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/curryleafItem",
+    "seed_texture": "harvestcraft:items/curryleafitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/curryleaf_stage_0",
       "harvestcraft:blocks/crops/curryleaf_stage_0",

--- a/mod_harvestcraft/plants/eggplant_plant.json
+++ b/mod_harvestcraft/plants/eggplant_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Eggplant Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:eggplantseedItem",
+      "item": "harvestcraft:eggplantseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:eggplantItem",
+        "item": "harvestcraft:eggplantitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/eggplantItem",
+    "seed_texture": "harvestcraft:items/eggplantitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/eggplant_stage_0",
       "harvestcraft:blocks/crops/eggplant_stage_0",

--- a/mod_harvestcraft/plants/garlic_plant.json
+++ b/mod_harvestcraft/plants/garlic_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Garlic Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:garlicseedItem",
+      "item": "harvestcraft:garlicseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:garlicItem",
+        "item": "harvestcraft:garlicitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/garlicItem",
+    "seed_texture": "harvestcraft:items/garlicitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/garlic_stage_0",
       "harvestcraft:blocks/crops/garlic_stage_0",

--- a/mod_harvestcraft/plants/ginger_plant.json
+++ b/mod_harvestcraft/plants/ginger_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Ginger Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:gingerseedItem",
+      "item": "harvestcraft:gingerseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:gingerItem",
+        "item": "harvestcraft:gingeritem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/gingerItem",
+    "seed_texture": "harvestcraft:items/gingeritem",
     "plant_textures": [
       "harvestcraft:blocks/crops/ginger_stage_0",
       "harvestcraft:blocks/crops/ginger_stage_0",

--- a/mod_harvestcraft/plants/grape_plant.json
+++ b/mod_harvestcraft/plants/grape_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Grape Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:grapeseedItem",
+      "item": "harvestcraft:grapeseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:grapeItem",
+        "item": "harvestcraft:grapeitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/grapeItem",
+    "seed_texture": "harvestcraft:items/grapeitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/grape_stage_0",
       "harvestcraft:blocks/crops/grape_stage_0",

--- a/mod_harvestcraft/plants/kiwi_plant.json
+++ b/mod_harvestcraft/plants/kiwi_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Kiwi Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:kiwiseedItem",
+      "item": "harvestcraft:kiwiseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:kiwiItem",
+        "item": "harvestcraft:kiwiitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/kiwiItem",
+    "seed_texture": "harvestcraft:items/kiwiitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/kiwi_stage_0",
       "harvestcraft:blocks/crops/kiwi_stage_0",

--- a/mod_harvestcraft/plants/leek_plant.json
+++ b/mod_harvestcraft/plants/leek_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Leek Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:leekseedItem",
+      "item": "harvestcraft:leekseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:leekItem",
+        "item": "harvestcraft:leekitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/leekItem",
+    "seed_texture": "harvestcraft:items/leekitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/leek_stage_0",
       "harvestcraft:blocks/crops/leek_stage_0",

--- a/mod_harvestcraft/plants/lettuce_plant.json
+++ b/mod_harvestcraft/plants/lettuce_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Lettuce Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:lettuceseedItem",
+      "item": "harvestcraft:lettuceseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:lettuceItem",
+        "item": "harvestcraft:lettuceitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/lettuceseedItem",
+    "seed_texture": "harvestcraft:items/lettuceseeditem",
     "plant_textures": [
       "harvestcraft:blocks/crops/lettuce_stage_0",
       "harvestcraft:blocks/crops/lettuce_stage_0",

--- a/mod_harvestcraft/plants/mustard_plant.json
+++ b/mod_harvestcraft/plants/mustard_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Mustard Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:mustardseedItem",
+      "item": "harvestcraft:mustardseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:mustardseedsItem",
+        "item": "harvestcraft:mustardseedsitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/mustardseedItem",
+    "seed_texture": "harvestcraft:items/mustardseeditem",
     "plant_textures": [
       "harvestcraft:blocks/crops/mustardseeds_stage_0",
       "harvestcraft:blocks/crops/mustardseeds_stage_0",

--- a/mod_harvestcraft/plants/oats_plant.json
+++ b/mod_harvestcraft/plants/oats_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Oats Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:oatsseedItem",
+      "item": "harvestcraft:oatsseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:oatsItem",
+        "item": "harvestcraft:oatsitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/oatsseedItem",
+    "seed_texture": "harvestcraft:items/oatsseeditem",
     "plant_textures": [
       "harvestcraft:blocks/crops/oats_stage_0",
       "harvestcraft:blocks/crops/oats_stage_0",

--- a/mod_harvestcraft/plants/okra_plant.json
+++ b/mod_harvestcraft/plants/okra_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Okra Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:okraseedItem",
+      "item": "harvestcraft:okraseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:okraItem",
+        "item": "harvestcraft:okraitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/okraItem",
+    "seed_texture": "harvestcraft:items/okraitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/okra_stage_0",
       "harvestcraft:blocks/crops/okra_stage_0",

--- a/mod_harvestcraft/plants/onion_plant.json
+++ b/mod_harvestcraft/plants/onion_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Onion Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:onionseedItem",
+      "item": "harvestcraft:onionseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:onionItem",
+        "item": "harvestcraft:onionitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/onionItem",
+    "seed_texture": "harvestcraft:items/onionitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/onion_stage_0",
       "harvestcraft:blocks/crops/onion_stage_0",

--- a/mod_harvestcraft/plants/parsnip_plant.json
+++ b/mod_harvestcraft/plants/parsnip_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Parsnip Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:parsnipseedItem",
+      "item": "harvestcraft:parsnipseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:parsnipItem",
+        "item": "harvestcraft:parsnipitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/parsnipItem",
+    "seed_texture": "harvestcraft:items/parsnipitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/parsnip_stage_0",
       "harvestcraft:blocks/crops/parsnip_stage_0",

--- a/mod_harvestcraft/plants/peanut_plant.json
+++ b/mod_harvestcraft/plants/peanut_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Peanut Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:peanutseedItem",
+      "item": "harvestcraft:peanutseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:peanutItem",
+        "item": "harvestcraft:peanutitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/peanutItem",
+    "seed_texture": "harvestcraft:items/peanutitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/peanut_stage_0",
       "harvestcraft:blocks/crops/peanut_stage_0",

--- a/mod_harvestcraft/plants/peas_plant.json
+++ b/mod_harvestcraft/plants/peas_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Peas Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:peasseedItem",
+      "item": "harvestcraft:peasseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:peasItem",
+        "item": "harvestcraft:peasitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/peasItem",
+    "seed_texture": "harvestcraft:items/peasitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/peas_stage_0",
       "harvestcraft:blocks/crops/peas_stage_0",

--- a/mod_harvestcraft/plants/pineapple_plant.json
+++ b/mod_harvestcraft/plants/pineapple_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Pineapple Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:pineappleseedItem",
+      "item": "harvestcraft:pineappleseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:pineappleItem",
+        "item": "harvestcraft:pineappleitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/pineappleItem",
+    "seed_texture": "harvestcraft:items/pineappleitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/pineapple_stage_0",
       "harvestcraft:blocks/crops/pineapple_stage_0",

--- a/mod_harvestcraft/plants/radish_plant.json
+++ b/mod_harvestcraft/plants/radish_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Radish Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:radishseedItem",
+      "item": "harvestcraft:radishseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:radishItem",
+        "item": "harvestcraft:radishitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/radishItem",
+    "seed_texture": "harvestcraft:items/radishitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/radish_stage_0",
       "harvestcraft:blocks/crops/radish_stage_0",

--- a/mod_harvestcraft/plants/raspberry_plant.json
+++ b/mod_harvestcraft/plants/raspberry_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Raspberry Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:raspberryseedItem",
+      "item": "harvestcraft:raspberryseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:raspberryItem",
+        "item": "harvestcraft:raspberryitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/raspberryItem",
+    "seed_texture": "harvestcraft:items/raspberryitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/raspberry_stage_0",
       "harvestcraft:blocks/crops/raspberry_stage_0",

--- a/mod_harvestcraft/plants/rhubarb_plant.json
+++ b/mod_harvestcraft/plants/rhubarb_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Rhubarb Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:rhubarbseedItem",
+      "item": "harvestcraft:rhubarbseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:rhubarbItem",
+        "item": "harvestcraft:rhubarbitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/rhubarbItem",
+    "seed_texture": "harvestcraft:items/rhubarbitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/rhubarb_stage_0",
       "harvestcraft:blocks/crops/rhubarb_stage_0",

--- a/mod_harvestcraft/plants/rice_plant.json
+++ b/mod_harvestcraft/plants/rice_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Rice Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:riceseedItem",
+      "item": "harvestcraft:riceseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:riceItem",
+        "item": "harvestcraft:riceitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/riceItem",
+    "seed_texture": "harvestcraft:items/riceitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/rice_stage_0",
       "harvestcraft:blocks/crops/rice_stage_0",

--- a/mod_harvestcraft/plants/rutabaga_plant.json
+++ b/mod_harvestcraft/plants/rutabaga_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Rutabaga Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:rutabagaseedItem",
+      "item": "harvestcraft:rutabagaseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:rutabagaItem",
+        "item": "harvestcraft:rutabagaitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/rutabagaItem",
+    "seed_texture": "harvestcraft:items/rutabagaitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/rutabaga_stage_0",
       "harvestcraft:blocks/crops/rutabaga_stage_0",

--- a/mod_harvestcraft/plants/rye_plant.json
+++ b/mod_harvestcraft/plants/rye_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Rye Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:ryeseedItem",
+      "item": "harvestcraft:ryeseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:ryeItem",
+        "item": "harvestcraft:ryeitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/ryeItem",
+    "seed_texture": "harvestcraft:items/ryeitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/rye_stage_0",
       "harvestcraft:blocks/crops/rye_stage_0",

--- a/mod_harvestcraft/plants/scallion_plant.json
+++ b/mod_harvestcraft/plants/scallion_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Scallion Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:scallionseedItem",
+      "item": "harvestcraft:scallionseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:scallionItem",
+        "item": "harvestcraft:scallionitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/scallionseedItem",
+    "seed_texture": "harvestcraft:items/scallionseeditem",
     "plant_textures": [
       "harvestcraft:blocks/crops/scallion_stage_0",
       "harvestcraft:blocks/crops/scallion_stage_0",

--- a/mod_harvestcraft/plants/seaweed_plant.json
+++ b/mod_harvestcraft/plants/seaweed_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Seaweed Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:seaweedseedItem",
+      "item": "harvestcraft:seaweedseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:seaweedItem",
+        "item": "harvestcraft:seaweeditem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/seaweedItem",
+    "seed_texture": "harvestcraft:items/seaweeditem",
     "plant_textures": [
       "harvestcraft:blocks/crops/seaweed_stage_0",
       "harvestcraft:blocks/crops/seaweed_stage_0",

--- a/mod_harvestcraft/plants/sesameseed_plant.json
+++ b/mod_harvestcraft/plants/sesameseed_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Sesame Seeds Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:sesameseedsseedItem",
+      "item": "harvestcraft:sesameseedsseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:sesameseedsItem",
+        "item": "harvestcraft:sesameseedsitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/sesameseedsItem",
+    "seed_texture": "harvestcraft:items/sesameseedsitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/sesameseeds_stage_0",
       "harvestcraft:blocks/crops/sesameseeds_stage_0",

--- a/mod_harvestcraft/plants/soybean_plant.json
+++ b/mod_harvestcraft/plants/soybean_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Soybean Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:soybeanseedItem",
+      "item": "harvestcraft:soybeanseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:soybeanItem",
+        "item": "harvestcraft:soybeanitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/soybeanItem",
+    "seed_texture": "harvestcraft:items/soybeanitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/soybean_stage_0",
       "harvestcraft:blocks/crops/soybean_stage_0",

--- a/mod_harvestcraft/plants/spiceleaf_plant.json
+++ b/mod_harvestcraft/plants/spiceleaf_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Spiceleaf Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:spiceleafseedItem",
+      "item": "harvestcraft:spiceleafseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:spiceleafItem",
+        "item": "harvestcraft:spiceleafitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/spiceleafItem",
+    "seed_texture": "harvestcraft:items/spiceleafitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/spiceleaf_stage_0",
       "harvestcraft:blocks/crops/spiceleaf_stage_0",

--- a/mod_harvestcraft/plants/spinach_plant.json
+++ b/mod_harvestcraft/plants/spinach_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Spinach Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:spinachseedItem",
+      "item": "harvestcraft:spinachseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:spinachItem",
+        "item": "harvestcraft:spinachitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/spinachItem",
+    "seed_texture": "harvestcraft:items/spinachitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/spinach_stage_0",
       "harvestcraft:blocks/crops/spinach_stage_0",

--- a/mod_harvestcraft/plants/strawberry_plant.json
+++ b/mod_harvestcraft/plants/strawberry_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Strawberry Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:strawberryseedItem",
+      "item": "harvestcraft:strawberryseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:strawberryItem",
+        "item": "harvestcraft:strawberryitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/strawberryItem",
+    "seed_texture": "harvestcraft:items/strawberryitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/strawberry_stage_0",
       "harvestcraft:blocks/crops/strawberry_stage_0",

--- a/mod_harvestcraft/plants/sweetpotato_plant.json
+++ b/mod_harvestcraft/plants/sweetpotato_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Sweet Potato Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:sweetpotatoseedItem",
+      "item": "harvestcraft:sweetpotatoseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:sweetpotatoItem",
+        "item": "harvestcraft:sweetpotatoitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/sweetpotatoItem",
+    "seed_texture": "harvestcraft:items/sweetpotatoitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/sweetpotato_stage_0",
       "harvestcraft:blocks/crops/sweetpotato_stage_0",

--- a/mod_harvestcraft/plants/tea_plant.json
+++ b/mod_harvestcraft/plants/tea_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Tea Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:teaseedItem",
+      "item": "harvestcraft:teaseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:tealeafItem",
+        "item": "harvestcraft:tealeafitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/teaItem",
+    "seed_texture": "harvestcraft:items/teaitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/tealeaf_stage_0",
       "harvestcraft:blocks/crops/tealeaf_stage_0",

--- a/mod_harvestcraft/plants/tomato_plant.json
+++ b/mod_harvestcraft/plants/tomato_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Tomato Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:tomatoseedItem",
+      "item": "harvestcraft:tomatoseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:tomatoItem",
+        "item": "harvestcraft:tomatoitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/tomatoItem",
+    "seed_texture": "harvestcraft:items/tomatoitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/tomato_stage_0",
       "harvestcraft:blocks/crops/tomato_stage_0",

--- a/mod_harvestcraft/plants/turnip_plant.json
+++ b/mod_harvestcraft/plants/turnip_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Turnip Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:turnipseedItem",
+      "item": "harvestcraft:turnipseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:turnipItem",
+        "item": "harvestcraft:turnipitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/turnipItem",
+    "seed_texture": "harvestcraft:items/turnipitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/turnip_stage_0",
       "harvestcraft:blocks/crops/turnip_stage_0",

--- a/mod_harvestcraft/plants/waterchestnut_plant.json
+++ b/mod_harvestcraft/plants/waterchestnut_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Water Chestnut Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:waterchestnutseedItem",
+      "item": "harvestcraft:waterchestnutseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:waterchestnutItem",
+        "item": "harvestcraft:waterchestnutitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/waterchestnutItem",
+    "seed_texture": "harvestcraft:items/waterchestnutitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/waterchestnut_stage_0",
       "harvestcraft:blocks/crops/waterchestnut_stage_0",

--- a/mod_harvestcraft/plants/whitemushroom_plant.json
+++ b/mod_harvestcraft/plants/whitemushroom_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "White Mushroom Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:whitemushroomseedItem",
+      "item": "harvestcraft:whitemushroomseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:whitemushroomItem",
+        "item": "harvestcraft:whitemushroomitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/whitemushroomItem",
+    "seed_texture": "harvestcraft:items/whitemushroomitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/whitemushroom_stage_0",
       "harvestcraft:blocks/crops/whitemushroom_stage_0",

--- a/mod_harvestcraft/plants/wintersquash_plant.json
+++ b/mod_harvestcraft/plants/wintersquash_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Winter Squash Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:wintersquashseedItem",
+      "item": "harvestcraft:wintersquashseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:wintersquashItem",
+        "item": "harvestcraft:wintersquashitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/wintersquashItem",
+    "seed_texture": "harvestcraft:items/wintersquashitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/wintersquash_stage_0",
       "harvestcraft:blocks/crops/wintersquash_stage_0",

--- a/mod_harvestcraft/plants/zucchini_plant.json
+++ b/mod_harvestcraft/plants/zucchini_plant.json
@@ -6,7 +6,7 @@
   "seed_name": "Zucchini Seeds",
   "seed_items": [
     {
-      "item": "harvestcraft:zucchiniseedItem",
+      "item": "harvestcraft:zucchiniseeditem",
       "meta": 0,
       "tags": "",
       "ignoreMeta": false,
@@ -38,7 +38,7 @@
         "max": 5,
         "chance": 0.9,
         "required": true,
-        "item": "harvestcraft:zucchiniItem",
+        "item": "harvestcraft:zucchiniitem",
         "meta": 0,
         "tags": "",
         "ignoreMeta": false,
@@ -57,7 +57,7 @@
   },
   "texture": {
     "render_type": "hash",
-    "seed_texture": "harvestcraft:items/zucchiniItem",
+    "seed_texture": "harvestcraft:items/zucchiniitem",
     "plant_textures": [
       "harvestcraft:blocks/crops/zucchini_stage_0",
       "harvestcraft:blocks/crops/zucchini_stage_0",


### PR DESCRIPTION
Should fix issue from [#988](https://github.com/AgriCraft/AgriCraft/issues/988)
Harvestcraft went to lowercase ids in latest update, changed  Item to item