### PR TITLE
Removed unused path config option

### DIFF
--- a/mod_Botania/mutations/botania_black_mutation.json
+++ b/mod_Botania/mutations/botania_black_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_Botania/mutations/botania_black_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "botania_black_plant",

--- a/mod_Botania/mutations/botania_blue_mutation.json
+++ b/mod_Botania/mutations/botania_blue_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_Botania/mutations/botania_blue_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "botania_blue_plant",

--- a/mod_Botania/mutations/botania_brown_mutation.json
+++ b/mod_Botania/mutations/botania_brown_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_Botania/mutations/botania_brown_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "botania_brown_plant",

--- a/mod_Botania/mutations/botania_cyan_mutation.json
+++ b/mod_Botania/mutations/botania_cyan_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_Botania/mutations/botania_cyan_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "botania_cyan_plant",

--- a/mod_Botania/mutations/botania_gray_mutation.json
+++ b/mod_Botania/mutations/botania_gray_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_Botania/mutations/botania_gray_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "botania_gray_plant",

--- a/mod_Botania/mutations/botania_green_mutation.json
+++ b/mod_Botania/mutations/botania_green_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_Botania/mutations/botania_green_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "botania_green_plant",

--- a/mod_Botania/mutations/botania_light_blue_mutation.json
+++ b/mod_Botania/mutations/botania_light_blue_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_Botania/mutations/botania_light_blue_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "botania_light_blue_plant",

--- a/mod_Botania/mutations/botania_light_gray_mutation.json
+++ b/mod_Botania/mutations/botania_light_gray_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_Botania/mutations/botania_light_gray_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "botania_light_gray_plant",

--- a/mod_Botania/mutations/botania_lime_mutation.json
+++ b/mod_Botania/mutations/botania_lime_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_Botania/mutations/botania_lime_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "botania_lime_plant",

--- a/mod_Botania/mutations/botania_magenta_mutation.json
+++ b/mod_Botania/mutations/botania_magenta_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_Botania/mutations/botania_magenta_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "botania_magenta_plant",

--- a/mod_Botania/mutations/botania_orange_mutation.json
+++ b/mod_Botania/mutations/botania_orange_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_Botania/mutations/botania_orange_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "botania_orange_plant",

--- a/mod_Botania/mutations/botania_pink_mutation.json
+++ b/mod_Botania/mutations/botania_pink_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_Botania/mutations/botania_pink_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "botania_pink_plant",

--- a/mod_Botania/mutations/botania_purple_mutation.json
+++ b/mod_Botania/mutations/botania_purple_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_Botania/mutations/botania_purple_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "botania_purple_plant",

--- a/mod_Botania/mutations/botania_red_mutation.json
+++ b/mod_Botania/mutations/botania_red_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_Botania/mutations/botania_red_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "botania_red_plant",

--- a/mod_Botania/mutations/botania_white_mutation.json
+++ b/mod_Botania/mutations/botania_white_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_Botania/mutations/botania_white_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "botania_white_plant",

--- a/mod_Botania/mutations/botania_yellow_mutation.json
+++ b/mod_Botania/mutations/botania_yellow_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_Botania/mutations/botania_yellow_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "botania_yellow_plant",

--- a/mod_Botania/plants/botania_black_plant.json
+++ b/mod_Botania/plants/botania_black_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_Botania/plants/botania_black_plant.json",
   "enabled": true,
   "id": "botania_black_plant",
   "plant_name": "Mystical Black Flower",

--- a/mod_Botania/plants/botania_blue_plant.json
+++ b/mod_Botania/plants/botania_blue_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_Botania/plants/botania_blue_plant.json",
   "enabled": true,
   "id": "botania_blue_plant",
   "plant_name": "Mystical Blue Flower",

--- a/mod_Botania/plants/botania_brown_plant.json
+++ b/mod_Botania/plants/botania_brown_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_Botania/plants/botania_brown_plant.json",
   "enabled": true,
   "id": "botania_brown_plant",
   "plant_name": "Mystical Brown Flower",

--- a/mod_Botania/plants/botania_cyan_plant.json
+++ b/mod_Botania/plants/botania_cyan_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_Botania/plants/botania_cyan_plant.json",
   "enabled": true,
   "id": "botania_cyan_plant",
   "plant_name": "Mystical Cyan Flower",

--- a/mod_Botania/plants/botania_gray_plant.json
+++ b/mod_Botania/plants/botania_gray_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_Botania/plants/botania_gray_plant.json",
   "enabled": true,
   "id": "botania_gray_plant",
   "plant_name": "Mystical Gray Flower",

--- a/mod_Botania/plants/botania_green_plant.json
+++ b/mod_Botania/plants/botania_green_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_Botania/plants/botania_green_plant.json",
   "enabled": true,
   "id": "botania_green_plant",
   "plant_name": "Mystical Green Flower",

--- a/mod_Botania/plants/botania_light_blue_plant.json
+++ b/mod_Botania/plants/botania_light_blue_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_Botania/plants/botania_light_blue_plant.json",
   "enabled": true,
   "id": "botania_light_blue_plant",
   "plant_name": "Mystical Light Blue Flower",

--- a/mod_Botania/plants/botania_light_gray_plant.json
+++ b/mod_Botania/plants/botania_light_gray_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_Botania/plants/botania_light_gray_plant.json",
   "enabled": true,
   "id": "botania_light_gray_plant",
   "plant_name": "Mystical Light Gray Flower",

--- a/mod_Botania/plants/botania_lime_plant.json
+++ b/mod_Botania/plants/botania_lime_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_Botania/plants/botania_lime_plant.json",
   "enabled": true,
   "id": "botania_lime_plant",
   "plant_name": "Mystical Lime Flower",

--- a/mod_Botania/plants/botania_magenta_plant.json
+++ b/mod_Botania/plants/botania_magenta_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_Botania/plants/botania_magenta_plant.json",
   "enabled": true,
   "id": "botania_magenta_plant",
   "plant_name": "Mystical Magenta Flower",

--- a/mod_Botania/plants/botania_orange_plant.json
+++ b/mod_Botania/plants/botania_orange_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_Botania/plants/botania_orange_plant.json",
   "enabled": true,
   "id": "botania_orange_plant",
   "plant_name": "Mystical Orange Flower",

--- a/mod_Botania/plants/botania_pink_plant.json
+++ b/mod_Botania/plants/botania_pink_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_Botania/plants/botania_pink_plant.json",
   "enabled": true,
   "id": "botania_pink_plant",
   "plant_name": "Mystical Pink Flower",

--- a/mod_Botania/plants/botania_purple_plant.json
+++ b/mod_Botania/plants/botania_purple_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_Botania/plants/botania_purple_plant.json",
   "enabled": true,
   "id": "botania_purple_plant",
   "plant_name": "Mystical Purple Flower",

--- a/mod_Botania/plants/botania_red_plant.json
+++ b/mod_Botania/plants/botania_red_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_Botania/plants/botania_red_plant.json",
   "enabled": true,
   "id": "botania_red_plant",
   "plant_name": "Mystical Red Flower",

--- a/mod_Botania/plants/botania_white_plant.json
+++ b/mod_Botania/plants/botania_white_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_Botania/plants/botania_white_plant.json",
   "enabled": true,
   "id": "botania_white_plant",
   "plant_name": "Mystical White Flower",

--- a/mod_Botania/plants/botania_yellow_plant.json
+++ b/mod_Botania/plants/botania_yellow_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_Botania/plants/botania_yellow_plant.json",
   "enabled": true,
   "id": "botania_yellow_plant",
   "plant_name": "Mystical Yellow Flower",

--- a/mod_Botania/soils/podzol_soil.json
+++ b/mod_Botania/soils/podzol_soil.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_Botania/soils/podzol_soil.json",
   "enabled": true,
   "id": "podzol_soil",
   "name": "podzol",

--- a/mod_actuallyadditions/canola_plant.json
+++ b/mod_actuallyadditions/canola_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_actuallyadditions/canola_plant.json",
   "enabled": true,
   "id": "canola_plant",
   "plant_name": "Canola",

--- a/mod_actuallyadditions/coffee_plant.json
+++ b/mod_actuallyadditions/coffee_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_actuallyadditions/coffee_plant.json",
   "enabled": true,
   "id": "coffee_plant",
   "plant_name": "Coffee",

--- a/mod_actuallyadditions/flax_plant.json
+++ b/mod_actuallyadditions/flax_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_actuallyadditions/flax_plant.json",
   "enabled": true,
   "id": "flax_plant",
   "plant_name": "Flax",

--- a/mod_actuallyadditions/rice_plant.json
+++ b/mod_actuallyadditions/rice_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_actuallyadditions/rice_plant.json",
   "enabled": true,
   "id": "rice_plant",
   "plant_name": "Rice",

--- a/mod_agriculturalexpansion/plants/alubrass_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/alubrass_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/alubrass_sprout_plant.json",
   "enabled": true,
   "id": "alubrass_sprout",
   "plant_name": "Alubrass Crop",

--- a/mod_agriculturalexpansion/plants/aluminum_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/aluminum_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/aluminum_sprout_plant.json",
   "enabled": true,
   "id": "aluminum_sprout",
   "plant_name": "Aluminum Crop",

--- a/mod_agriculturalexpansion/plants/amber_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/amber_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/amber_sprout_plant.json",
   "enabled": true,
   "id": "amber_sprout",
   "plant_name": "Amber Crop",

--- a/mod_agriculturalexpansion/plants/apatite_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/apatite_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/apatite_sprout_plant.json",
   "enabled": true,
   "id": "apatite_sprout",
   "plant_name": "Apatite Crop",

--- a/mod_agriculturalexpansion/plants/ardite_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/ardite_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/ardite_sprout_plant.json",
   "enabled": true,
   "id": "ardite_sprout",
   "plant_name": "Ardite Crop",

--- a/mod_agriculturalexpansion/plants/blaze_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/blaze_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/blaze_sprout_plant.json",
   "enabled": true,
   "id": "blaze_sprout",
   "plant_name": "Blaze Crop",

--- a/mod_agriculturalexpansion/plants/brass_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/brass_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/brass_sprout_plant.json",
   "enabled": true,
   "id": "brass_sprout",
   "plant_name": "Brass Crop",

--- a/mod_agriculturalexpansion/plants/bronze_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/bronze_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/bronze_sprout_plant.json",
   "enabled": true,
   "id": "bronze_sprout",
   "plant_name": "Bronze Crop",

--- a/mod_agriculturalexpansion/plants/chicken_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/chicken_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/chicken_sprout_plant.json",
   "enabled": true,
   "id": "chicken_sprout",
   "plant_name": "Chicken Crop",

--- a/mod_agriculturalexpansion/plants/coal_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/coal_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/coal_sprout_plant.json",
   "enabled": true,
   "id": "coal_sprout",
   "plant_name": "Coal Crop",

--- a/mod_agriculturalexpansion/plants/cobalt_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/cobalt_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/cobalt_sprout_plant.json",
   "enabled": true,
   "id": "cobalt_sprout",
   "plant_name": "Cobalt Crop",

--- a/mod_agriculturalexpansion/plants/copper_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/copper_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/copper_sprout_plant.json",
   "enabled": true,
   "id": "copper_sprout",
   "plant_name": "Copper Crop",

--- a/mod_agriculturalexpansion/plants/cow_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/cow_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/cow_sprout_plant.json",
   "enabled": true,
   "id": "cow_sprout",
   "plant_name": "Cow Crop",

--- a/mod_agriculturalexpansion/plants/creeper_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/creeper_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/creeper_sprout_plant.json",
   "enabled": true,
   "id": "creeper_sprout",
   "plant_name": "Creeper Crop",

--- a/mod_agriculturalexpansion/plants/diamond_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/diamond_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/diamond_sprout_plant.json",
   "enabled": true,
   "id": "diamond_sprout",
   "plant_name": "Diamond Crop",

--- a/mod_agriculturalexpansion/plants/dye_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/dye_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/dye_sprout_plant.json",
   "enabled": true,
   "id": "dye_sprout",
   "plant_name": "Dye Crop",

--- a/mod_agriculturalexpansion/plants/earth_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/earth_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/earth_sprout_plant.json",
   "enabled": true,
   "id": "earth_sprout",
   "plant_name": "Earth Crop",

--- a/mod_agriculturalexpansion/plants/electrum_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/electrum_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/electrum_sprout_plant.json",
   "enabled": true,
   "id": "electrum_sprout",
   "plant_name": "Electrum Crop",

--- a/mod_agriculturalexpansion/plants/emerald_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/emerald_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/emerald_sprout_plant.json",
   "enabled": true,
   "id": "emerald_sprout",
   "plant_name": "Emerald Crop",

--- a/mod_agriculturalexpansion/plants/enderman_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/enderman_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/enderman_sprout_plant.json",
   "enabled": true,
   "id": "enderman_sprout",
   "plant_name": "Enderman Crop",

--- a/mod_agriculturalexpansion/plants/experience_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/experience_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/experience_sprout_plant.json",
   "enabled": true,
   "id": "experience_sprout",
   "plant_name": "Experience Crop",

--- a/mod_agriculturalexpansion/plants/fire_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/fire_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/fire_sprout_plant.json",
   "enabled": true,
   "id": "fire_sprout",
   "plant_name": "Fire Crop",

--- a/mod_agriculturalexpansion/plants/ghast_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/ghast_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/ghast_sprout_plant.json",
   "enabled": true,
   "id": "ghast_sprout",
   "plant_name": "Ghast Crop",

--- a/mod_agriculturalexpansion/plants/glowstone_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/glowstone_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/glowstone_sprout_plant.json",
   "enabled": true,
   "id": "glowstone_sprout",
   "plant_name": "Glowstone Crop",

--- a/mod_agriculturalexpansion/plants/gold_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/gold_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/gold_sprout_plant.json",
   "enabled": true,
   "id": "gold_sprout",
   "plant_name": "Gold Crop",

--- a/mod_agriculturalexpansion/plants/guardian_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/guardian_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/guardian_sprout_plant.json",
   "enabled": true,
   "id": "guardian_sprout",
   "plant_name": "Guardian Crop",

--- a/mod_agriculturalexpansion/plants/invar_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/invar_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/invar_sprout_plant.json",
   "enabled": true,
   "id": "invar_sprout",
   "plant_name": "Invar Crop",

--- a/mod_agriculturalexpansion/plants/iridium_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/iridium_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/iridium_sprout_plant.json",
   "enabled": true,
   "id": "iridium_sprout",
   "plant_name": "Iridium Crop",

--- a/mod_agriculturalexpansion/plants/iron_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/iron_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/iron_sprout_plant.json",
   "enabled": true,
   "id": "iron_sprout",
   "plant_name": "Iron Crop",

--- a/mod_agriculturalexpansion/plants/lapis_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/lapis_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/lapis_sprout_plant.json",
   "enabled": true,
   "id": "lapis_sprout",
   "plant_name": "Lapis Crop",

--- a/mod_agriculturalexpansion/plants/lead_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/lead_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/lead_sprout_plant.json",
   "enabled": true,
   "id": "lead_sprout",
   "plant_name": "Lead Crop",

--- a/mod_agriculturalexpansion/plants/malachite_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/malachite_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/malachite_sprout_plant.json",
   "enabled": true,
   "id": "malachite_sprout",
   "plant_name": "Malachite Crop",

--- a/mod_agriculturalexpansion/plants/manyullyn_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/manyullyn_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/manyullyn_sprout_plant.json",
   "enabled": true,
   "id": "manyullyn_sprout",
   "plant_name": "Manyullyn Crop",

--- a/mod_agriculturalexpansion/plants/nature_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/nature_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/nature_sprout_plant.json",
   "enabled": true,
   "id": "nature_sprout",
   "plant_name": "Nature Crop",

--- a/mod_agriculturalexpansion/plants/nether_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/nether_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/nether_sprout_plant.json",
   "enabled": true,
   "id": "nether_sprout",
   "plant_name": "Nether Crop",

--- a/mod_agriculturalexpansion/plants/nickel_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/nickel_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/nickel_sprout_plant.json",
   "enabled": true,
   "id": "nickel_sprout",
   "plant_name": "Nickel Crop",

--- a/mod_agriculturalexpansion/plants/peridot_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/peridot_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/peridot_sprout_plant.json",
   "enabled": true,
   "id": "peridot_sprout",
   "plant_name": "Peridot Crop",

--- a/mod_agriculturalexpansion/plants/pig_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/pig_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/pig_sprout_plant.json",
   "enabled": true,
   "id": "pig_sprout",
   "plant_name": "Pig Crop",

--- a/mod_agriculturalexpansion/plants/platinum_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/platinum_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/platinum_sprout_plant.json",
   "enabled": true,
   "id": "platinum_sprout",
   "plant_name": "Platinum Crop",

--- a/mod_agriculturalexpansion/plants/quartz_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/quartz_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/quartz_sprout_plant.json",
   "enabled": true,
   "id": "quartz_sprout",
   "plant_name": "Quartz Crop",

--- a/mod_agriculturalexpansion/plants/rabbit_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/rabbit_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/rabbit_sprout_plant.json",
   "enabled": true,
   "id": "rabbit_sprout",
   "plant_name": "Rabbit Crop",

--- a/mod_agriculturalexpansion/plants/redstone_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/redstone_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/redstone_sprout_plant.json",
   "enabled": true,
   "id": "redstone_sprout",
   "plant_name": "Redstone Crop",

--- a/mod_agriculturalexpansion/plants/resource_seed_plant.json
+++ b/mod_agriculturalexpansion/plants/resource_seed_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/resource_seed_plant.json",
   "enabled": true,
   "id": "resource_seed",
   "plant_name": "Resource Crop",

--- a/mod_agriculturalexpansion/plants/rubber_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/rubber_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/rubber_sprout_plant.json",
   "enabled": true,
   "id": "rubber_sprout",
   "plant_name": "Rubber Crop",

--- a/mod_agriculturalexpansion/plants/ruby_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/ruby_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/ruby_sprout_plant.json",
   "enabled": true,
   "id": "ruby_sprout",
   "plant_name": "Ruby Crop",

--- a/mod_agriculturalexpansion/plants/sapphire_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/sapphire_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/sapphire_sprout_plant.json",
   "enabled": true,
   "id": "sapphire_sprout",
   "plant_name": "Sapphire Crop",

--- a/mod_agriculturalexpansion/plants/sheep_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/sheep_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/sheep_sprout_plant.json",
   "enabled": true,
   "id": "sheep_sprout",
   "plant_name": "Sheep Crop",

--- a/mod_agriculturalexpansion/plants/silver_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/silver_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/silver_sprout_plant.json",
   "enabled": true,
   "id": "silver_sprout",
   "plant_name": "Silver Crop",

--- a/mod_agriculturalexpansion/plants/skeleton_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/skeleton_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/skeleton_sprout_plant.json",
   "enabled": true,
   "id": "skeleton_sprout",
   "plant_name": "Skeleton Crop",

--- a/mod_agriculturalexpansion/plants/slime_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/slime_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/slime_sprout_plant.json",
   "enabled": true,
   "id": "slime_sprout",
   "plant_name": "Slime Crop",

--- a/mod_agriculturalexpansion/plants/spider_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/spider_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/spider_sprout_plant.json",
   "enabled": true,
   "id": "spider_sprout",
   "plant_name": "Spider Crop",

--- a/mod_agriculturalexpansion/plants/squid_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/squid_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/squid_sprout_plant.json",
   "enabled": true,
   "id": "squid_sprout",
   "plant_name": "Squid Crop",

--- a/mod_agriculturalexpansion/plants/steel_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/steel_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/steel_sprout_plant.json",
   "enabled": true,
   "id": "steel_sprout",
   "plant_name": "Steel Crop",

--- a/mod_agriculturalexpansion/plants/tanzanite_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/tanzanite_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/tanzanite_sprout_plant.json",
   "enabled": true,
   "id": "tanzanite_sprout",
   "plant_name": "Tanzanite Crop",

--- a/mod_agriculturalexpansion/plants/tin_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/tin_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/tin_sprout_plant.json",
   "enabled": true,
   "id": "tin_sprout",
   "plant_name": "Tin Crop",

--- a/mod_agriculturalexpansion/plants/titanium_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/titanium_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/titanium_sprout_plant.json",
   "enabled": true,
   "id": "titanium_sprout",
   "plant_name": "Titanium Crop",

--- a/mod_agriculturalexpansion/plants/topaz_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/topaz_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/topaz_sprout_plant.json",
   "enabled": true,
   "id": "topaz_sprout",
   "plant_name": "Topaz Crop",

--- a/mod_agriculturalexpansion/plants/tungsten_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/tungsten_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/tungsten_sprout_plant.json",
   "enabled": true,
   "id": "tungsten_sprout",
   "plant_name": "Tungsten Crop",

--- a/mod_agriculturalexpansion/plants/water_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/water_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/water_sprout_plant.json",
   "enabled": true,
   "id": "water_sprout",
   "plant_name": "Water Crop",

--- a/mod_agriculturalexpansion/plants/wither_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/wither_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/wither_sprout_plant.json",
   "enabled": true,
   "id": "wither_sprout",
   "plant_name": "Wither Crop",

--- a/mod_agriculturalexpansion/plants/zinc_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/zinc_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/zinc_sprout_plant.json",
   "enabled": true,
   "id": "zinc_sprout",
   "plant_name": "Zinc Crop",

--- a/mod_agriculturalexpansion/plants/zombie_sprout_plant.json
+++ b/mod_agriculturalexpansion/plants/zombie_sprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_agriculturalexpansion/plants/zombie_sprout_plant.json",
   "enabled": true,
   "id": "zombie_sprout",
   "plant_name": "Zombie Crop",

--- a/mod_harvestcraft/mutations/artichoke_mutation.json
+++ b/mod_harvestcraft/mutations/artichoke_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/artichoke_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "artichoke_plant",

--- a/mod_harvestcraft/mutations/asparagus_mutation.json
+++ b/mod_harvestcraft/mutations/asparagus_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/asparagus_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "asparagus_plant",

--- a/mod_harvestcraft/mutations/bambooshoot_mutation.json
+++ b/mod_harvestcraft/mutations/bambooshoot_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/bambooshoot_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "bambooshoot_plant",

--- a/mod_harvestcraft/mutations/barley_mutation.json
+++ b/mod_harvestcraft/mutations/barley_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/barley_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "barley_plant",

--- a/mod_harvestcraft/mutations/bean_mutation.json
+++ b/mod_harvestcraft/mutations/bean_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/bean_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "bean_plant",

--- a/mod_harvestcraft/mutations/beet_mutation.json
+++ b/mod_harvestcraft/mutations/beet_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/beet_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "beet_plant",

--- a/mod_harvestcraft/mutations/bellpepper_mutation.json
+++ b/mod_harvestcraft/mutations/bellpepper_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/bellpepper_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "bellpepper_plant",

--- a/mod_harvestcraft/mutations/blackberry_mutation.json
+++ b/mod_harvestcraft/mutations/blackberry_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/blackberry_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "blackberry_plant",

--- a/mod_harvestcraft/mutations/blueberry_mutation.json
+++ b/mod_harvestcraft/mutations/blueberry_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/blueberry_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "blueberry_plant",

--- a/mod_harvestcraft/mutations/broccoli_mutation.json
+++ b/mod_harvestcraft/mutations/broccoli_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/broccoli_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "broccoli_plant",

--- a/mod_harvestcraft/mutations/brusselsprout_mutation.json
+++ b/mod_harvestcraft/mutations/brusselsprout_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/brusselsprout_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "brusselsprout_plant",

--- a/mod_harvestcraft/mutations/cabbage_mutation.json
+++ b/mod_harvestcraft/mutations/cabbage_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/cabbage_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "cabbage_plant",

--- a/mod_harvestcraft/mutations/cactusfruit_mutation.json
+++ b/mod_harvestcraft/mutations/cactusfruit_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/cactusfruit_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "cactusfruit_plant",

--- a/mod_harvestcraft/mutations/candleberry_mutation.json
+++ b/mod_harvestcraft/mutations/candleberry_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/candleberry_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "candleberry_plant",

--- a/mod_harvestcraft/mutations/cantaloupe_mutation.json
+++ b/mod_harvestcraft/mutations/cantaloupe_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/cantaloupe_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "cantaloupe_plant",

--- a/mod_harvestcraft/mutations/cauliflower_mutation.json
+++ b/mod_harvestcraft/mutations/cauliflower_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/cauliflower_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "cauliflower_plant",

--- a/mod_harvestcraft/mutations/celery_mutation.json
+++ b/mod_harvestcraft/mutations/celery_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/celery_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "celery_plant",

--- a/mod_harvestcraft/mutations/chilipepper_mutation.json
+++ b/mod_harvestcraft/mutations/chilipepper_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/chilipepper_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "chilipepper_plant",

--- a/mod_harvestcraft/mutations/coffee_mutation.json
+++ b/mod_harvestcraft/mutations/coffee_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/coffee_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "coffee_plant",

--- a/mod_harvestcraft/mutations/corn_mutation.json
+++ b/mod_harvestcraft/mutations/corn_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/corn_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "corn_plant",

--- a/mod_harvestcraft/mutations/cotton_mutation.json
+++ b/mod_harvestcraft/mutations/cotton_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/cotton_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "cotton_plant",

--- a/mod_harvestcraft/mutations/cranberry_mutation.json
+++ b/mod_harvestcraft/mutations/cranberry_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/cranberry_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "cranberry_plant",

--- a/mod_harvestcraft/mutations/cucumber_mutation.json
+++ b/mod_harvestcraft/mutations/cucumber_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/cucumber_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "cucumber_plant",

--- a/mod_harvestcraft/mutations/curryleaf_mutation.json
+++ b/mod_harvestcraft/mutations/curryleaf_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/curryleaf_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "curryleaf_plant",

--- a/mod_harvestcraft/mutations/eggplant_mutation.json
+++ b/mod_harvestcraft/mutations/eggplant_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/eggplant_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "eggplant_plant",

--- a/mod_harvestcraft/mutations/garlic_mutation.json
+++ b/mod_harvestcraft/mutations/garlic_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/garlic_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "garlic_plant",

--- a/mod_harvestcraft/mutations/ginger_mutation.json
+++ b/mod_harvestcraft/mutations/ginger_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/ginger_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "ginger_plant",

--- a/mod_harvestcraft/mutations/grape_mutation.json
+++ b/mod_harvestcraft/mutations/grape_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/grape_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "grape_plant",

--- a/mod_harvestcraft/mutations/kiwi_mutation.json
+++ b/mod_harvestcraft/mutations/kiwi_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/kiwi_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "kiwi_plant",

--- a/mod_harvestcraft/mutations/leek_mutation.json
+++ b/mod_harvestcraft/mutations/leek_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/leek_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "leek_plant",

--- a/mod_harvestcraft/mutations/lettuce_mutation.json
+++ b/mod_harvestcraft/mutations/lettuce_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/lettuce_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "lettuce_plant",

--- a/mod_harvestcraft/mutations/mustard_mutation.json
+++ b/mod_harvestcraft/mutations/mustard_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/mustard_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "mustard_plant",

--- a/mod_harvestcraft/mutations/oats_mutation.json
+++ b/mod_harvestcraft/mutations/oats_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/oats_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "oats_plant",

--- a/mod_harvestcraft/mutations/okra_mutation.json
+++ b/mod_harvestcraft/mutations/okra_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/okra_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "okra_plant",

--- a/mod_harvestcraft/mutations/onion_mutation.json
+++ b/mod_harvestcraft/mutations/onion_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/onion_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "onion_plant",

--- a/mod_harvestcraft/mutations/parsnip_mutation.json
+++ b/mod_harvestcraft/mutations/parsnip_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/parsnip_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "parsnip_plant",

--- a/mod_harvestcraft/mutations/peanut_mutation.json
+++ b/mod_harvestcraft/mutations/peanut_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/peanut_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "peanut_plant",

--- a/mod_harvestcraft/mutations/peas_mutation.json
+++ b/mod_harvestcraft/mutations/peas_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/peas_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "peas_plant",

--- a/mod_harvestcraft/mutations/pineapple_mutation.json
+++ b/mod_harvestcraft/mutations/pineapple_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/pineapple_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "pineapple_plant",

--- a/mod_harvestcraft/mutations/radish_mutation.json
+++ b/mod_harvestcraft/mutations/radish_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/radish_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "radish_plant",

--- a/mod_harvestcraft/mutations/raspberry_mutation.json
+++ b/mod_harvestcraft/mutations/raspberry_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/raspberry_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "raspberry_plant",

--- a/mod_harvestcraft/mutations/rhubarb_mutation.json
+++ b/mod_harvestcraft/mutations/rhubarb_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/rhubarb_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "rhubarb_plant",

--- a/mod_harvestcraft/mutations/rice_mutation.json
+++ b/mod_harvestcraft/mutations/rice_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/rice_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "rice_plant",

--- a/mod_harvestcraft/mutations/rutabaga_mutation.json
+++ b/mod_harvestcraft/mutations/rutabaga_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/rutabaga_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "rutabaga_plant",

--- a/mod_harvestcraft/mutations/rye_mutation.json
+++ b/mod_harvestcraft/mutations/rye_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/rye_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "rye_plant",

--- a/mod_harvestcraft/mutations/scallion_mutation.json
+++ b/mod_harvestcraft/mutations/scallion_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/scallion_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "scallion_plant",

--- a/mod_harvestcraft/mutations/seaweed_mutation.json
+++ b/mod_harvestcraft/mutations/seaweed_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/seaweed_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "seaweed_plant",

--- a/mod_harvestcraft/mutations/sesameseeds_mutation.json
+++ b/mod_harvestcraft/mutations/sesameseeds_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/sesameseeds_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "sesameseed_plant",

--- a/mod_harvestcraft/mutations/soybean_mutation.json
+++ b/mod_harvestcraft/mutations/soybean_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/soybean_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "soybean_plant",

--- a/mod_harvestcraft/mutations/spiceleaf_mutation.json
+++ b/mod_harvestcraft/mutations/spiceleaf_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/spiceleaf_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "spiceleaf_plant",

--- a/mod_harvestcraft/mutations/spinach_mutation.json
+++ b/mod_harvestcraft/mutations/spinach_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/spinach_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "spinach_plant",

--- a/mod_harvestcraft/mutations/strawberry_mutation.json
+++ b/mod_harvestcraft/mutations/strawberry_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/strawberry_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "strawberry_plant",

--- a/mod_harvestcraft/mutations/sweetpotato_mutation.json
+++ b/mod_harvestcraft/mutations/sweetpotato_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/sweetpotato_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "sweetpotato_plant",

--- a/mod_harvestcraft/mutations/tea_mutation.json
+++ b/mod_harvestcraft/mutations/tea_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/tea_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "tea_plant",

--- a/mod_harvestcraft/mutations/tomato_mutation.json
+++ b/mod_harvestcraft/mutations/tomato_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/tomato_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "tomato_plant",

--- a/mod_harvestcraft/mutations/turnip_mutation.json
+++ b/mod_harvestcraft/mutations/turnip_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/turnip_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "turnip_plant",

--- a/mod_harvestcraft/mutations/waterchestnut_mutation.json
+++ b/mod_harvestcraft/mutations/waterchestnut_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/waterchestnut_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "waterchestnut_plant",

--- a/mod_harvestcraft/mutations/whitemushroom_mutation.json
+++ b/mod_harvestcraft/mutations/whitemushroom_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/whitemushroom_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "whitemushroom_plant",

--- a/mod_harvestcraft/mutations/wintersquash_mutation.json
+++ b/mod_harvestcraft/mutations/wintersquash_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/wintersquash_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "wintersquash_plant",

--- a/mod_harvestcraft/mutations/zucchini_mutation.json
+++ b/mod_harvestcraft/mutations/zucchini_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/mutations/zucchini_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "zucchini_plant",

--- a/mod_harvestcraft/plants/artichoke_plant.json
+++ b/mod_harvestcraft/plants/artichoke_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/artichoke_plant.json",
   "enabled": true,
   "id": "artichoke_plant",
   "plant_name": "Artichoke",

--- a/mod_harvestcraft/plants/asparagus_plant.json
+++ b/mod_harvestcraft/plants/asparagus_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/asparagus_plant.json",
   "enabled": true,
   "id": "asparagus_plant",
   "plant_name": "Asparagus",

--- a/mod_harvestcraft/plants/bambooshoot_plant.json
+++ b/mod_harvestcraft/plants/bambooshoot_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/bambooshoot_plant.json",
   "enabled": true,
   "id": "bambooshoot_plant",
   "plant_name": "Bamboo Shoot",

--- a/mod_harvestcraft/plants/barley_plant.json
+++ b/mod_harvestcraft/plants/barley_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/barley_plant.json",
   "enabled": true,
   "id": "barley_plant",
   "plant_name": "Barley",

--- a/mod_harvestcraft/plants/bean_plant.json
+++ b/mod_harvestcraft/plants/bean_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/bean_plant.json",
   "enabled": true,
   "id": "bean_plant",
   "plant_name": "Bean",

--- a/mod_harvestcraft/plants/beet_plant.json
+++ b/mod_harvestcraft/plants/beet_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/beet_plant.json",
   "enabled": true,
   "id": "beet_plant",
   "plant_name": "Beet",

--- a/mod_harvestcraft/plants/bellpepper_plant.json
+++ b/mod_harvestcraft/plants/bellpepper_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/bellpepper_plant.json",
   "enabled": true,
   "id": "bellpepper_plant",
   "plant_name": "Bellpepper",

--- a/mod_harvestcraft/plants/blackberry_plant.json
+++ b/mod_harvestcraft/plants/blackberry_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/blackberry_plant.json",
   "enabled": true,
   "id": "blackberry_plant",
   "plant_name": "Blackberry",

--- a/mod_harvestcraft/plants/blueberry_plant.json
+++ b/mod_harvestcraft/plants/blueberry_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/blueberry_plant.json",
   "enabled": true,
   "id": "blueberry_plant",
   "plant_name": "Blueberry",

--- a/mod_harvestcraft/plants/broccoli_plant.json
+++ b/mod_harvestcraft/plants/broccoli_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/broccoli_plant.json",
   "enabled": true,
   "id": "broccoli_plant",
   "plant_name": "Broccoli",

--- a/mod_harvestcraft/plants/brusselsprout_plant.json
+++ b/mod_harvestcraft/plants/brusselsprout_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/brusselsprout_plant.json",
   "enabled": true,
   "id": "brusselsprout_plant",
   "plant_name": "Brussel Sprout",

--- a/mod_harvestcraft/plants/cabbage_plant.json
+++ b/mod_harvestcraft/plants/cabbage_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/cabbage_plant.json",
   "enabled": true,
   "id": "cabbage_plant",
   "plant_name": "Cabbage",

--- a/mod_harvestcraft/plants/cactusfruit_plant.json
+++ b/mod_harvestcraft/plants/cactusfruit_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/cactusfruit_plant.json",
   "enabled": true,
   "id": "cactusfruit_plant",
   "plant_name": "Cactus Fruit",

--- a/mod_harvestcraft/plants/candleberry_plant.json
+++ b/mod_harvestcraft/plants/candleberry_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/candleberry_plant.json",
   "enabled": true,
   "id": "candleberry_plant",
   "plant_name": "Candleberry",

--- a/mod_harvestcraft/plants/cantaloupe_plant.json
+++ b/mod_harvestcraft/plants/cantaloupe_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/cantaloupe_plant.json",
   "enabled": true,
   "id": "cantaloupe_plant",
   "plant_name": "Cantaloupe",

--- a/mod_harvestcraft/plants/cauliflower_plant.json
+++ b/mod_harvestcraft/plants/cauliflower_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/cauliflower_plant.json",
   "enabled": true,
   "id": "cauliflower_plant",
   "plant_name": "Cauliflower",

--- a/mod_harvestcraft/plants/celery_plant.json
+++ b/mod_harvestcraft/plants/celery_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/celery_plant.json",
   "enabled": true,
   "id": "celery_plant",
   "plant_name": "Celery",

--- a/mod_harvestcraft/plants/chilipepper_plant.json
+++ b/mod_harvestcraft/plants/chilipepper_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/chilipepper_plant.json",
   "enabled": true,
   "id": "chilipepper_plant",
   "plant_name": "Chili Pepper",

--- a/mod_harvestcraft/plants/coffee_plant.json
+++ b/mod_harvestcraft/plants/coffee_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/coffee_plant.json",
   "enabled": true,
   "id": "coffee_plant",
   "plant_name": "Coffee",

--- a/mod_harvestcraft/plants/corn_plant.json
+++ b/mod_harvestcraft/plants/corn_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/corn_plant.json",
   "enabled": true,
   "id": "corn_plant",
   "plant_name": "Corn",

--- a/mod_harvestcraft/plants/cotton_plant.json
+++ b/mod_harvestcraft/plants/cotton_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/cotton_plant.json",
   "enabled": true,
   "id": "cotton_plant",
   "plant_name": "Cotton",

--- a/mod_harvestcraft/plants/cranberry_plant.json
+++ b/mod_harvestcraft/plants/cranberry_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/cranberry_plant.json",
   "enabled": true,
   "id": "cranberry_plant",
   "plant_name": "Cranberry",

--- a/mod_harvestcraft/plants/cucumber_plant.json
+++ b/mod_harvestcraft/plants/cucumber_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/cucumber_plant.json",
   "enabled": true,
   "id": "cucumber_plant",
   "plant_name": "Cucumber",

--- a/mod_harvestcraft/plants/curryleaf_plant.json
+++ b/mod_harvestcraft/plants/curryleaf_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/curryleaf_plant.json",
   "enabled": true,
   "id": "curryleaf_plant",
   "plant_name": "Curryleaf",

--- a/mod_harvestcraft/plants/eggplant_plant.json
+++ b/mod_harvestcraft/plants/eggplant_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/eggplant_plant.json",
   "enabled": true,
   "id": "eggplant_plant",
   "plant_name": "Eggplant",

--- a/mod_harvestcraft/plants/garlic_plant.json
+++ b/mod_harvestcraft/plants/garlic_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/garlic_plant.json",
   "enabled": true,
   "id": "garlic_plant",
   "plant_name": "Garlic",

--- a/mod_harvestcraft/plants/ginger_plant.json
+++ b/mod_harvestcraft/plants/ginger_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/ginger_plant.json",
   "enabled": true,
   "id": "ginger_plant",
   "plant_name": "Ginger",

--- a/mod_harvestcraft/plants/grape_plant.json
+++ b/mod_harvestcraft/plants/grape_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/grape_plant.json",
   "enabled": true,
   "id": "grape_plant",
   "plant_name": "Grape",

--- a/mod_harvestcraft/plants/kiwi_plant.json
+++ b/mod_harvestcraft/plants/kiwi_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/kiwi_plant.json",
   "enabled": true,
   "id": "kiwi_plant",
   "plant_name": "Kiwi",

--- a/mod_harvestcraft/plants/leek_plant.json
+++ b/mod_harvestcraft/plants/leek_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/leek_plant.json",
   "enabled": true,
   "id": "leek_plant",
   "plant_name": "Leek",

--- a/mod_harvestcraft/plants/lettuce_plant.json
+++ b/mod_harvestcraft/plants/lettuce_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/lettuce_plant.json",
   "enabled": true,
   "id": "lettuce_plant",
   "plant_name": "Lettuce",

--- a/mod_harvestcraft/plants/mustard_plant.json
+++ b/mod_harvestcraft/plants/mustard_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/mustard_plant.json",
   "enabled": true,
   "id": "mustard_plant",
   "plant_name": "Mustard",

--- a/mod_harvestcraft/plants/oats_plant.json
+++ b/mod_harvestcraft/plants/oats_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/oats_plant.json",
   "enabled": true,
   "id": "oats_plant",
   "plant_name": "Oats",

--- a/mod_harvestcraft/plants/okra_plant.json
+++ b/mod_harvestcraft/plants/okra_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/okra_plant.json",
   "enabled": true,
   "id": "okra_plant",
   "plant_name": "Okra",

--- a/mod_harvestcraft/plants/onion_plant.json
+++ b/mod_harvestcraft/plants/onion_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/onion_plant.json",
   "enabled": true,
   "id": "onion_plant",
   "plant_name": "Onion",

--- a/mod_harvestcraft/plants/parsnip_plant.json
+++ b/mod_harvestcraft/plants/parsnip_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/parsnip_plant.json",
   "enabled": true,
   "id": "parsnip_plant",
   "plant_name": "Parsnip",

--- a/mod_harvestcraft/plants/peanut_plant.json
+++ b/mod_harvestcraft/plants/peanut_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/peanut_plant.json",
   "enabled": true,
   "id": "peanut_plant",
   "plant_name": "Peanut",

--- a/mod_harvestcraft/plants/peas_plant.json
+++ b/mod_harvestcraft/plants/peas_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/peas_plant.json",
   "enabled": true,
   "id": "peas_plant",
   "plant_name": "Peas",

--- a/mod_harvestcraft/plants/pineapple_plant.json
+++ b/mod_harvestcraft/plants/pineapple_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/pineapple_plant.json",
   "enabled": true,
   "id": "pineapple_plant",
   "plant_name": "Pineapple",

--- a/mod_harvestcraft/plants/radish_plant.json
+++ b/mod_harvestcraft/plants/radish_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/radish_plant.json",
   "enabled": true,
   "id": "radish_plant",
   "plant_name": "Radish",

--- a/mod_harvestcraft/plants/raspberry_plant.json
+++ b/mod_harvestcraft/plants/raspberry_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/raspberry_plant.json",
   "enabled": true,
   "id": "raspberry_plant",
   "plant_name": "Raspberry",

--- a/mod_harvestcraft/plants/rhubarb_plant.json
+++ b/mod_harvestcraft/plants/rhubarb_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/rhubarb_plant.json",
   "enabled": true,
   "id": "rhubarb_plant",
   "plant_name": "Rhubarb",

--- a/mod_harvestcraft/plants/rice_plant.json
+++ b/mod_harvestcraft/plants/rice_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/rice_plant.json",
   "enabled": true,
   "id": "rice_plant",
   "plant_name": "Rice",

--- a/mod_harvestcraft/plants/rutabaga_plant.json
+++ b/mod_harvestcraft/plants/rutabaga_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/rutabaga_plant.json",
   "enabled": true,
   "id": "rutabaga_plant",
   "plant_name": "Rutabaga",

--- a/mod_harvestcraft/plants/rye_plant.json
+++ b/mod_harvestcraft/plants/rye_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/rye_plant.json",
   "enabled": true,
   "id": "rye_plant",
   "plant_name": "Rye",

--- a/mod_harvestcraft/plants/scallion_plant.json
+++ b/mod_harvestcraft/plants/scallion_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/scallion_plant.json",
   "enabled": true,
   "id": "scallion_plant",
   "plant_name": "Scallion",

--- a/mod_harvestcraft/plants/seaweed_plant.json
+++ b/mod_harvestcraft/plants/seaweed_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/seaweed_plant.json",
   "enabled": true,
   "id": "seaweed_plant",
   "plant_name": "Seaweed",

--- a/mod_harvestcraft/plants/sesameseed_plant.json
+++ b/mod_harvestcraft/plants/sesameseed_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/sesameseed_plant.json",
   "enabled": true,
   "id": "sesameseed_plant",
   "plant_name": "Sesame Seeds",

--- a/mod_harvestcraft/plants/soybean_plant.json
+++ b/mod_harvestcraft/plants/soybean_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/soybean_plant.json",
   "enabled": true,
   "id": "soybean_plant",
   "plant_name": "Soybean",

--- a/mod_harvestcraft/plants/spiceleaf_plant.json
+++ b/mod_harvestcraft/plants/spiceleaf_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/spiceleaf_plant.json",
   "enabled": true,
   "id": "spiceleaf_plant",
   "plant_name": "Spiceleaf",

--- a/mod_harvestcraft/plants/spinach_plant.json
+++ b/mod_harvestcraft/plants/spinach_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/spinach_plant.json",
   "enabled": true,
   "id": "spinach_plant",
   "plant_name": "Spinach",

--- a/mod_harvestcraft/plants/strawberry_plant.json
+++ b/mod_harvestcraft/plants/strawberry_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/strawberry_plant.json",
   "enabled": true,
   "id": "strawberry_plant",
   "plant_name": "Strawberry",

--- a/mod_harvestcraft/plants/sweetpotato_plant.json
+++ b/mod_harvestcraft/plants/sweetpotato_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/sweetpotato_plant.json",
   "enabled": true,
   "id": "sweetpotato_plant",
   "plant_name": "Sweet Potato",

--- a/mod_harvestcraft/plants/tea_plant.json
+++ b/mod_harvestcraft/plants/tea_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/tea_plant.json",
   "enabled": true,
   "id": "tea_plant",
   "plant_name": "Tea",

--- a/mod_harvestcraft/plants/tomato_plant.json
+++ b/mod_harvestcraft/plants/tomato_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/tomato_plant.json",
   "enabled": true,
   "id": "tomato_plant",
   "plant_name": "Tomato",

--- a/mod_harvestcraft/plants/turnip_plant.json
+++ b/mod_harvestcraft/plants/turnip_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/turnip_plant.json",
   "enabled": true,
   "id": "turnip_plant",
   "plant_name": "Turnip",

--- a/mod_harvestcraft/plants/waterchestnut_plant.json
+++ b/mod_harvestcraft/plants/waterchestnut_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/waterchestnut_plant.json",
   "enabled": true,
   "id": "waterchestnut_plant",
   "plant_name": "Water Chestnut",

--- a/mod_harvestcraft/plants/whitemushroom_plant.json
+++ b/mod_harvestcraft/plants/whitemushroom_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/whitemushroom_plant.json",
   "enabled": true,
   "id": "whitemushroom_plant",
   "plant_name": "White Mushroom",

--- a/mod_harvestcraft/plants/wintersquash_plant.json
+++ b/mod_harvestcraft/plants/wintersquash_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/wintersquash_plant.json",
   "enabled": true,
   "id": "wintersquash_plant",
   "plant_name": "Winter Squash",

--- a/mod_harvestcraft/plants/zucchini_plant.json
+++ b/mod_harvestcraft/plants/zucchini_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_harvestcraft/plants/zucchini_plant.json",
   "enabled": true,
   "id": "zucchini_plant",
   "plant_name": "Zucchini",

--- a/mod_immersiveengineering/hemp_plant.json
+++ b/mod_immersiveengineering/hemp_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_immersiveengineering/hemp_plant.json",
   "enabled": true,
   "id": "hemp_plant",
   "plant_name": "Hemp",

--- a/mod_mysticalagradditions/awakened_draconium_plant.json
+++ b/mod_mysticalagradditions/awakened_draconium_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagradditions/awakened_draconium_plant.json",
   "enabled": true,
   "id": "awakened_draconium_plant",
   "plant_name": "Awakened Draconium Crop",

--- a/mod_mysticalagradditions/nether_star_plant.json
+++ b/mod_mysticalagradditions/nether_star_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagradditions/nether_star_plant.json",
   "enabled": true,
   "id": "nether_star_plant",
   "plant_name": "Nether Star Crop",

--- a/mod_mysticalagradditions/tier6_inferium_plant.json
+++ b/mod_mysticalagradditions/tier6_inferium_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagradditions/tier6_inferium_plant.json",
   "enabled": true,
   "id": "tier6_inferium_plant",
   "plant_name": "Tier6 Inferium Crop",

--- a/mod_mysticalagriculture/plants/aluminum_brass_plant.json
+++ b/mod_mysticalagriculture/plants/aluminum_brass_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/aluminum_brass_plant.json",
   "enabled": true,
   "id": "aluminum_brass_plant",
   "plant_name": "Aluminum Brass Crop",

--- a/mod_mysticalagriculture/plants/aluminum_plant.json
+++ b/mod_mysticalagriculture/plants/aluminum_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/aluminum_plant.json",
   "enabled": true,
   "id": "aluminum_plant",
   "plant_name": "Aluminum Crop",

--- a/mod_mysticalagriculture/plants/amber_plant.json
+++ b/mod_mysticalagriculture/plants/amber_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/amber_plant.json",
   "enabled": true,
   "id": "amber_plant",
   "plant_name": "Amber",

--- a/mod_mysticalagriculture/plants/apatite_plant.json
+++ b/mod_mysticalagriculture/plants/apatite_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/apatite_plant.json",
   "enabled": true,
   "id": "apatite_plant",
   "plant_name": "Apatite Crop",

--- a/mod_mysticalagriculture/plants/ardite_plant.json
+++ b/mod_mysticalagriculture/plants/ardite_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/ardite_plant.json",
   "enabled": true,
   "id": "ardite_plant",
   "plant_name": "Ardite Crop",

--- a/mod_mysticalagriculture/plants/basalt_plant.json
+++ b/mod_mysticalagriculture/plants/basalt_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/basalt_plant.json",
   "enabled": true,
   "id": "basalt_plant",
   "plant_name": "Basalt",

--- a/mod_mysticalagriculture/plants/basalz_plant.json
+++ b/mod_mysticalagriculture/plants/basalz_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/basalz_plant.json",
   "enabled": true,
   "id": "basalz_plant",
   "plant_name": "Basalz Crop",

--- a/mod_mysticalagriculture/plants/blaze_plant.json
+++ b/mod_mysticalagriculture/plants/blaze_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/blaze_plant.json",
   "enabled": true,
   "id": "blaze_plant",
   "plant_name": "Blaze Crop",

--- a/mod_mysticalagriculture/plants/blitz_plant.json
+++ b/mod_mysticalagriculture/plants/blitz_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/blitz_plant.json",
   "enabled": true,
   "id": "blitz_plant",
   "plant_name": "Blitz Crop",

--- a/mod_mysticalagriculture/plants/blizz_plant.json
+++ b/mod_mysticalagriculture/plants/blizz_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/blizz_plant.json",
   "enabled": true,
   "id": "blizz_plant",
   "plant_name": "Blizz Crop",

--- a/mod_mysticalagriculture/plants/blue_topaz_plant.json
+++ b/mod_mysticalagriculture/plants/blue_topaz_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/blue_topaz_plant.json",
   "enabled": true,
   "id": "blue_topaz_plant",
   "plant_name": "Blue Topaz Crop",

--- a/mod_mysticalagriculture/plants/brass_plant.json
+++ b/mod_mysticalagriculture/plants/brass_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/brass_plant.json",
   "enabled": true,
   "id": "brass_plant",
   "plant_name": "Brass Crop",

--- a/mod_mysticalagriculture/plants/bronze_plant.json
+++ b/mod_mysticalagriculture/plants/bronze_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/bronze_plant.json",
   "enabled": true,
   "id": "bronze_plant",
   "plant_name": "Bronze Crop",

--- a/mod_mysticalagriculture/plants/certus_quartz_plant.json
+++ b/mod_mysticalagriculture/plants/certus_quartz_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/certus_quartz_plant.json",
   "enabled": true,
   "id": "certus_quartz_plant",
   "plant_name": "Certus Quartz",

--- a/mod_mysticalagriculture/plants/chicken_plant.json
+++ b/mod_mysticalagriculture/plants/chicken_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/chicken_plant.json",
   "enabled": true,
   "id": "chicken_plant",
   "plant_name": "Chicken Crop",

--- a/mod_mysticalagriculture/plants/chimerite_plant.json
+++ b/mod_mysticalagriculture/plants/chimerite_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/chimerite_plant.json",
   "enabled": true,
   "id": "chimerite_plant",
   "plant_name": "Chimerite Crop",

--- a/mod_mysticalagriculture/plants/coal_plant.json
+++ b/mod_mysticalagriculture/plants/coal_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/coal_plant.json",
   "enabled": true,
   "id": "coal_plant",
   "plant_name": "Coal Crop",

--- a/mod_mysticalagriculture/plants/cobalt_plant.json
+++ b/mod_mysticalagriculture/plants/cobalt_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/cobalt_plant.json",
   "enabled": true,
   "id": "cobalt_plant",
   "plant_name": "Cobalt",

--- a/mod_mysticalagriculture/plants/conductive_iron_plant.json
+++ b/mod_mysticalagriculture/plants/conductive_iron_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/conductive_iron_plant.json",
   "enabled": true,
   "id": "conductive_iron_plant",
   "plant_name": "Conductive Iron Crop",

--- a/mod_mysticalagriculture/plants/constantan_plant.json
+++ b/mod_mysticalagriculture/plants/constantan_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/constantan_plant.json",
   "enabled": true,
   "id": "constantan_plant",
   "plant_name": "Constantan Crop",

--- a/mod_mysticalagriculture/plants/copper_plant.json
+++ b/mod_mysticalagriculture/plants/copper_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/copper_plant.json",
   "enabled": true,
   "id": "copper_plant",
   "plant_name": "Copper Crop",

--- a/mod_mysticalagriculture/plants/cow_plant.json
+++ b/mod_mysticalagriculture/plants/cow_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/cow_plant.json",
   "enabled": true,
   "id": "cow_plant",
   "plant_name": "Cow Crop",

--- a/mod_mysticalagriculture/plants/creeper_plant.json
+++ b/mod_mysticalagriculture/plants/creeper_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/creeper_plant.json",
   "enabled": true,
   "id": "creeper_plant",
   "plant_name": "Creeper Crop",

--- a/mod_mysticalagriculture/plants/dark_steel_plant.json
+++ b/mod_mysticalagriculture/plants/dark_steel_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/dark_steel_plant.json",
   "enabled": true,
   "id": "dark_steel_plant",
   "plant_name": "Dark Steel Crop",

--- a/mod_mysticalagriculture/plants/diamond_plant.json
+++ b/mod_mysticalagriculture/plants/diamond_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/diamond_plant.json",
   "enabled": true,
   "id": "diamond_plant",
   "plant_name": "Diamond Crop",

--- a/mod_mysticalagriculture/plants/dirt_plant.json
+++ b/mod_mysticalagriculture/plants/dirt_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/dirt_plant.json",
   "enabled": true,
   "id": "dirt_plant",
   "plant_name": "Dirt Crop",

--- a/mod_mysticalagriculture/plants/draconium_plant.json
+++ b/mod_mysticalagriculture/plants/draconium_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/draconium_plant.json",
   "enabled": true,
   "id": "draconium_plant",
   "plant_name": "Draconium",

--- a/mod_mysticalagriculture/plants/dye_plant.json
+++ b/mod_mysticalagriculture/plants/dye_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/dye_plant.json",
   "enabled": true,
   "id": "dye_plant",
   "plant_name": "Dye Crop",

--- a/mod_mysticalagriculture/plants/electrical_steel_plant.json
+++ b/mod_mysticalagriculture/plants/electrical_steel_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/electrical_steel_plant.json",
   "enabled": true,
   "id": "electrical_steel_plant",
   "plant_name": "Electrical Steel Crop",

--- a/mod_mysticalagriculture/plants/electrum_plant.json
+++ b/mod_mysticalagriculture/plants/electrum_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/electrum_plant.json",
   "enabled": true,
   "id": "electrum_plant",
   "plant_name": "Electrum Crop",

--- a/mod_mysticalagriculture/plants/emerald_plant.json
+++ b/mod_mysticalagriculture/plants/emerald_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/emerald_plant.json",
   "enabled": true,
   "id": "emerald_plant",
   "plant_name": "Emerald Crop",

--- a/mod_mysticalagriculture/plants/end_plant.json
+++ b/mod_mysticalagriculture/plants/end_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/end_plant.json",
   "enabled": true,
   "id": "end_plant",
   "plant_name": "End Crop",

--- a/mod_mysticalagriculture/plants/ender_amethyst_plant.json
+++ b/mod_mysticalagriculture/plants/ender_amethyst_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/ender_amethyst_plant.json",
   "enabled": true,
   "id": "ender_amethyst_plant",
   "plant_name": "Ender Amethyst",

--- a/mod_mysticalagriculture/plants/enderium_plant.json
+++ b/mod_mysticalagriculture/plants/enderium_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/enderium_plant.json",
   "enabled": true,
   "id": "enderium_plant",
   "plant_name": "Enderium Crop",

--- a/mod_mysticalagriculture/plants/enderman_plant.json
+++ b/mod_mysticalagriculture/plants/enderman_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/enderman_plant.json",
   "enabled": true,
   "id": "enderman_plant",
   "plant_name": "Enderman Crop",

--- a/mod_mysticalagriculture/plants/energetic_alloy_plant.json
+++ b/mod_mysticalagriculture/plants/energetic_alloy_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/energetic_alloy_plant.json",
   "enabled": true,
   "id": "energetic_alloy_plant",
   "plant_name": "Energetic Alloy Crop",

--- a/mod_mysticalagriculture/plants/experience_plant.json
+++ b/mod_mysticalagriculture/plants/experience_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/experience_plant.json",
   "enabled": true,
   "id": "experience_plant",
   "plant_name": "Experience Crop",

--- a/mod_mysticalagriculture/plants/fire_plant.json
+++ b/mod_mysticalagriculture/plants/fire_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/fire_plant.json",
   "enabled": true,
   "id": "fire_plant",
   "plant_name": "Fire Crop",

--- a/mod_mysticalagriculture/plants/fluix_plant.json
+++ b/mod_mysticalagriculture/plants/fluix_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/fluix_plant.json",
   "enabled": true,
   "id": "fluix_plant",
   "plant_name": "Fluix",

--- a/mod_mysticalagriculture/plants/ghast_plant.json
+++ b/mod_mysticalagriculture/plants/ghast_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/ghast_plant.json",
   "enabled": true,
   "id": "ghast_plant",
   "plant_name": "Ghast Crop",

--- a/mod_mysticalagriculture/plants/glowstone_ingot_plant.json
+++ b/mod_mysticalagriculture/plants/glowstone_ingot_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/glowstone_ingot_plant.json",
   "enabled": true,
   "id": "glowstone_ingot_plant",
   "plant_name": "Glowstone Ingot",

--- a/mod_mysticalagriculture/plants/glowstone_plant.json
+++ b/mod_mysticalagriculture/plants/glowstone_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/glowstone_plant.json",
   "enabled": true,
   "id": "glowstone_plant",
   "plant_name": "Glowstone Crop",

--- a/mod_mysticalagriculture/plants/gold_plant.json
+++ b/mod_mysticalagriculture/plants/gold_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/gold_plant.json",
   "enabled": true,
   "id": "gold_plant",
   "plant_name": "Gold Crop",

--- a/mod_mysticalagriculture/plants/guardian_plant.json
+++ b/mod_mysticalagriculture/plants/guardian_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/guardian_plant.json",
   "enabled": true,
   "id": "guardian_plant",
   "plant_name": "Guardian Crop",

--- a/mod_mysticalagriculture/plants/ice_plant.json
+++ b/mod_mysticalagriculture/plants/ice_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/ice_plant.json",
   "enabled": true,
   "id": "ice_plant",
   "plant_name": "Ice Crop",

--- a/mod_mysticalagriculture/plants/invar_plant.json
+++ b/mod_mysticalagriculture/plants/invar_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/invar_plant.json",
   "enabled": true,
   "id": "invar_plant",
   "plant_name": "Invar Crop",

--- a/mod_mysticalagriculture/plants/iridium_plant.json
+++ b/mod_mysticalagriculture/plants/iridium_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/iridium_plant.json",
   "enabled": true,
   "id": "iridium_plant",
   "plant_name": "Iridium Crop",

--- a/mod_mysticalagriculture/plants/iron_plant.json
+++ b/mod_mysticalagriculture/plants/iron_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/iron_plant.json",
   "enabled": true,
   "id": "iron_plant",
   "plant_name": "Iron Crop",

--- a/mod_mysticalagriculture/plants/knightslime_plant.json
+++ b/mod_mysticalagriculture/plants/knightslime_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/knightslime_plant.json",
   "enabled": true,
   "id": "knightslime_plant",
   "plant_name": "Knightslime Crop",

--- a/mod_mysticalagriculture/plants/lapis_lazuli_plant.json
+++ b/mod_mysticalagriculture/plants/lapis_lazuli_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/lapis_lazuli_plant.json",
   "enabled": true,
   "id": "lapis_lazuli_plant",
   "plant_name": "Lapis Lazuli Crop",

--- a/mod_mysticalagriculture/plants/lead_plant.json
+++ b/mod_mysticalagriculture/plants/lead_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/lead_plant.json",
   "enabled": true,
   "id": "lead_plant",
   "plant_name": "Lead Crop",

--- a/mod_mysticalagriculture/plants/limestone_plant.json
+++ b/mod_mysticalagriculture/plants/limestone_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/limestone_plant.json",
   "enabled": true,
   "id": "limestone_plant",
   "plant_name": "Limestone",

--- a/mod_mysticalagriculture/plants/lumium_plant.json
+++ b/mod_mysticalagriculture/plants/lumium_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/lumium_plant.json",
   "enabled": true,
   "id": "lumium_plant",
   "plant_name": "Lumium Crop",

--- a/mod_mysticalagriculture/plants/malachite_plant.json
+++ b/mod_mysticalagriculture/plants/malachite_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/malachite_plant.json",
   "enabled": true,
   "id": "malachite_plant",
   "plant_name": "Malachite",

--- a/mod_mysticalagriculture/plants/manasteel_plant.json
+++ b/mod_mysticalagriculture/plants/manasteel_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/manasteel_plant.json",
   "enabled": true,
   "id": "manasteel_plant",
   "plant_name": "Manasteel",

--- a/mod_mysticalagriculture/plants/manyullyn_plant.json
+++ b/mod_mysticalagriculture/plants/manyullyn_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/manyullyn_plant.json",
   "enabled": true,
   "id": "manyullyn_plant",
   "plant_name": "Manyullyn Crop",

--- a/mod_mysticalagriculture/plants/marble_plant.json
+++ b/mod_mysticalagriculture/plants/marble_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/marble_plant.json",
   "enabled": true,
   "id": "marble_plant",
   "plant_name": "Marble",

--- a/mod_mysticalagriculture/plants/mithril_plant.json
+++ b/mod_mysticalagriculture/plants/mithril_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/mithril_plant.json",
   "enabled": true,
   "id": "mithril_plant",
   "plant_name": "Mithril Crop",

--- a/mod_mysticalagriculture/plants/moonstone_plant.json
+++ b/mod_mysticalagriculture/plants/moonstone_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/moonstone_plant.json",
   "enabled": true,
   "id": "moonstone_plant",
   "plant_name": "Moonstone Crop",

--- a/mod_mysticalagriculture/plants/mystical_flower_plant.json
+++ b/mod_mysticalagriculture/plants/mystical_flower_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/mystical_flower_plant.json",
   "enabled": true,
   "id": "mystical_flower_plant",
   "plant_name": "Mystical Flower Crop",

--- a/mod_mysticalagriculture/plants/nature_plant.json
+++ b/mod_mysticalagriculture/plants/nature_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/nature_plant.json",
   "enabled": true,
   "id": "nature_plant",
   "plant_name": "Nature Crop",

--- a/mod_mysticalagriculture/plants/nether_plant.json
+++ b/mod_mysticalagriculture/plants/nether_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/nether_plant.json",
   "enabled": true,
   "id": "nether_plant",
   "plant_name": "Nether Crop",

--- a/mod_mysticalagriculture/plants/nether_quartz_plant.json
+++ b/mod_mysticalagriculture/plants/nether_quartz_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/nether_quartz_plant.json",
   "enabled": true,
   "id": "nether_quartz_plant",
   "plant_name": "Nether Quartz Crop",

--- a/mod_mysticalagriculture/plants/nickel_plant.json
+++ b/mod_mysticalagriculture/plants/nickel_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/nickel_plant.json",
   "enabled": true,
   "id": "nickel_plant",
   "plant_name": "Nickel Crop",

--- a/mod_mysticalagriculture/plants/obsidian_plant.json
+++ b/mod_mysticalagriculture/plants/obsidian_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/obsidian_plant.json",
   "enabled": true,
   "id": "obsidian_plant",
   "plant_name": "Obsidian Crop",

--- a/mod_mysticalagriculture/plants/osmium_plant.json
+++ b/mod_mysticalagriculture/plants/osmium_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/osmium_plant.json",
   "enabled": true,
   "id": "osmium_plant",
   "plant_name": "Osmium",

--- a/mod_mysticalagriculture/plants/peridot_plant.json
+++ b/mod_mysticalagriculture/plants/peridot_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/peridot_plant.json",
   "enabled": true,
   "id": "peridot_plant",
   "plant_name": "Peridot",

--- a/mod_mysticalagriculture/plants/pig_plant.json
+++ b/mod_mysticalagriculture/plants/pig_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/pig_plant.json",
   "enabled": true,
   "id": "pig_plant",
   "plant_name": "Pig Crop",

--- a/mod_mysticalagriculture/plants/platinum_plant.json
+++ b/mod_mysticalagriculture/plants/platinum_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/platinum_plant.json",
   "enabled": true,
   "id": "platinum_plant",
   "plant_name": "Platinum Crop",

--- a/mod_mysticalagriculture/plants/pulsating_iron_plant.json
+++ b/mod_mysticalagriculture/plants/pulsating_iron_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/pulsating_iron_plant.json",
   "enabled": true,
   "id": "pulsating_iron_plant",
   "plant_name": "Pulsating Iron Crop",

--- a/mod_mysticalagriculture/plants/quartz_enriched_iron_plant.json
+++ b/mod_mysticalagriculture/plants/quartz_enriched_iron_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/quartz_enriched_iron_plant.json",
   "enabled": true,
   "id": "quartz_enriched_iron_plant",
   "plant_name": "Quartz Enriched Iron Crop",

--- a/mod_mysticalagriculture/plants/rabbit_plant.json
+++ b/mod_mysticalagriculture/plants/rabbit_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/rabbit_plant.json",
   "enabled": true,
   "id": "rabbit_plant",
   "plant_name": "Rabbit Crop",

--- a/mod_mysticalagriculture/plants/redstone_alloy_plant.json
+++ b/mod_mysticalagriculture/plants/redstone_alloy_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/redstone_alloy_plant.json",
   "enabled": true,
   "id": "redstone_alloy_plant",
   "plant_name": "Redstone Alloy Crop",

--- a/mod_mysticalagriculture/plants/redstone_plant.json
+++ b/mod_mysticalagriculture/plants/redstone_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/redstone_plant.json",
   "enabled": true,
   "id": "redstone_plant",
   "plant_name": "Redstone Crop",

--- a/mod_mysticalagriculture/plants/refined_obsidian_plant.json
+++ b/mod_mysticalagriculture/plants/refined_obsidian_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/refined_obsidian_plant.json",
   "enabled": true,
   "id": "refined_obsidian_plant",
   "plant_name": "Refined Obsidian",

--- a/mod_mysticalagriculture/plants/rubber_plant.json
+++ b/mod_mysticalagriculture/plants/rubber_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/rubber_plant.json",
   "enabled": true,
   "id": "rubber_plant",
   "plant_name": "Rubber",

--- a/mod_mysticalagriculture/plants/ruby_plant.json
+++ b/mod_mysticalagriculture/plants/ruby_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/ruby_plant.json",
   "enabled": true,
   "id": "rubyr_plant",
   "plant_name": "Ruby",

--- a/mod_mysticalagriculture/plants/sapphire_plant.json
+++ b/mod_mysticalagriculture/plants/sapphire_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/sapphire_plant.json",
   "enabled": true,
   "id": "sapphire_plant",
   "plant_name": "Sapphire",

--- a/mod_mysticalagriculture/plants/sheep_plant.json
+++ b/mod_mysticalagriculture/plants/sheep_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/sheep_plant.json",
   "enabled": true,
   "id": "sheep_plant",
   "plant_name": "Sheep Crop",

--- a/mod_mysticalagriculture/plants/signalum_plant.json
+++ b/mod_mysticalagriculture/plants/signalum_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/signalum_plant.json",
   "enabled": true,
   "id": "signalum_plant",
   "plant_name": "Signalum Crop",

--- a/mod_mysticalagriculture/plants/silver_plant.json
+++ b/mod_mysticalagriculture/plants/silver_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/silver_plant.json",
   "enabled": true,
   "id": "silver_plant",
   "plant_name": "Silver Crop",

--- a/mod_mysticalagriculture/plants/skeleton_plant.json
+++ b/mod_mysticalagriculture/plants/skeleton_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/skeleton_plant.json",
   "enabled": true,
   "id": "skeleton_plant",
   "plant_name": "Skeleton Crop",

--- a/mod_mysticalagriculture/plants/slime_plant.json
+++ b/mod_mysticalagriculture/plants/slime_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/slime_plant.json",
   "enabled": true,
   "id": "slime_plant",
   "plant_name": "Slime Crop",

--- a/mod_mysticalagriculture/plants/soularium_plant.json
+++ b/mod_mysticalagriculture/plants/soularium_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/soularium_plant.json",
   "enabled": true,
   "id": "soularium_plant",
   "plant_name": "Soularium Crop",

--- a/mod_mysticalagriculture/plants/spider_plant.json
+++ b/mod_mysticalagriculture/plants/spider_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/spider_plant.json",
   "enabled": true,
   "id": "spider_plant",
   "plant_name": "Spider Crop",

--- a/mod_mysticalagriculture/plants/steel_plant.json
+++ b/mod_mysticalagriculture/plants/steel_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/steel_plant.json",
   "enabled": true,
   "id": "steel_plant",
   "plant_name": "Steel Crop",

--- a/mod_mysticalagriculture/plants/stone_plant.json
+++ b/mod_mysticalagriculture/plants/stone_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/stone_plant.json",
   "enabled": true,
   "id": "stone_plant",
   "plant_name": "Stone Crop",

--- a/mod_mysticalagriculture/plants/sunstone_plant.json
+++ b/mod_mysticalagriculture/plants/sunstone_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/sunstone_plant.json",
   "enabled": true,
   "id": "sunstone_plant",
   "plant_name": "Sunstone Crop",

--- a/mod_mysticalagriculture/plants/tanzanite_plant.json
+++ b/mod_mysticalagriculture/plants/tanzanite_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/tanzanite_plant.json",
   "enabled": true,
   "id": "tanzanite_plant",
   "plant_name": "Tanzanite",

--- a/mod_mysticalagriculture/plants/terrasteel_plant.json
+++ b/mod_mysticalagriculture/plants/terrasteel_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/terrasteel_plant.json",
   "enabled": true,
   "id": "terrasteel_plant",
   "plant_name": "Terrasteel",

--- a/mod_mysticalagriculture/plants/tier1_inferium_plant.json
+++ b/mod_mysticalagriculture/plants/tier1_inferium_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/tier1_inferium_plant.json",
   "enabled": true,
   "id": "tier1_inferium_plant",
   "plant_name": "Tier1 Inferium Crop",

--- a/mod_mysticalagriculture/plants/tier2_inferium_plant.json
+++ b/mod_mysticalagriculture/plants/tier2_inferium_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/tier2_inferium_plant.json",
   "enabled": true,
   "id": "tier2_inferium_plant",
   "plant_name": "Tier2 Inferium Crop",

--- a/mod_mysticalagriculture/plants/tier3_inferium_plant.json
+++ b/mod_mysticalagriculture/plants/tier3_inferium_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/tier3_inferium_plant.json",
   "enabled": true,
   "id": "tier3_inferium_plant",
   "plant_name": "Tier3 Inferium Crop",

--- a/mod_mysticalagriculture/plants/tier4_inferium_plant.json
+++ b/mod_mysticalagriculture/plants/tier4_inferium_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/tier4_inferium_plant.json",
   "enabled": true,
   "id": "tier4_inferium_plant",
   "plant_name": "Tier4 Inferium Crop",

--- a/mod_mysticalagriculture/plants/tier5_inferium_plant.json
+++ b/mod_mysticalagriculture/plants/tier5_inferium_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/tier5_inferium_plant.json",
   "enabled": true,
   "id": "tier5_inferium_plant",
   "plant_name": "Tier5 Inferium Crop",

--- a/mod_mysticalagriculture/plants/tin_plant.json
+++ b/mod_mysticalagriculture/plants/tin_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/tin_plant.json",
   "enabled": true,
   "id": "tin_plant",
   "plant_name": "Tin Crop",

--- a/mod_mysticalagriculture/plants/titanium_plant.json
+++ b/mod_mysticalagriculture/plants/titanium_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/titanium_plant.json",
   "enabled": true,
   "id": "titanium_plant",
   "plant_name": "Titanium Crop",

--- a/mod_mysticalagriculture/plants/topaz_plant.json
+++ b/mod_mysticalagriculture/plants/topaz_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/topaz_plant.json",
   "enabled": true,
   "id": "topaz_plant",
   "plant_name": "Topaz",

--- a/mod_mysticalagriculture/plants/vibrant_alloy_plant.json
+++ b/mod_mysticalagriculture/plants/vibrant_alloy_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/vibrant_alloy_plant.json",
   "enabled": true,
   "id": "vibrant_alloy_plant",
   "plant_name": "Vibrant Alloy Crop",

--- a/mod_mysticalagriculture/plants/vinteum_plant.json
+++ b/mod_mysticalagriculture/plants/vinteum_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/vinteum_plant.json",
   "enabled": true,
   "id": "vinteum_plant",
   "plant_name": "Vinteum Crop",

--- a/mod_mysticalagriculture/plants/water_plant.json
+++ b/mod_mysticalagriculture/plants/water_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/water_plant.json",
   "enabled": true,
   "id": "water_plant",
   "plant_name": "Water Crop",

--- a/mod_mysticalagriculture/plants/wither_skeleton_plant.json
+++ b/mod_mysticalagriculture/plants/wither_skeleton_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/wither_skeleton_plant.json",
   "enabled": true,
   "id": "wither_skeleton_plant",
   "plant_name": "Wither Skeleton Crop",

--- a/mod_mysticalagriculture/plants/wood_plant.json
+++ b/mod_mysticalagriculture/plants/wood_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/wood_plant.json",
   "enabled": true,
   "id": "wood_plant",
   "plant_name": "Wood Crop",

--- a/mod_mysticalagriculture/plants/yellorium_plant.json
+++ b/mod_mysticalagriculture/plants/yellorium_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/yellorium_plant.json",
   "enabled": true,
   "id": "yellorium_plant",
   "plant_name": "Yellorium Crop",

--- a/mod_mysticalagriculture/plants/zinc_plant.json
+++ b/mod_mysticalagriculture/plants/zinc_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/zinc_plant.json",
   "enabled": true,
   "id": "zinc_plant",
   "plant_name": "Zinc Crop",

--- a/mod_mysticalagriculture/plants/zombie_plant.json
+++ b/mod_mysticalagriculture/plants/zombie_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/plants/zombie_plant.json",
   "enabled": true,
   "id": "zombie_plant",
   "plant_name": "Zombie Crop",

--- a/mod_mysticalagriculture/soils/farmland_soil.json
+++ b/mod_mysticalagriculture/soils/farmland_soil.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_mysticalagriculture/soils/farmland_soil.json",
   "enabled": true,
   "id": "farmland_soil",
   "name": "Farmland",

--- a/mod_natura/barley_plant.json
+++ b/mod_natura/barley_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_natura/barley_plant.json",
   "enabled": true,
   "id": "barley_plant",
   "plant_name": "Barley",

--- a/mod_natura/cotton_plant.json
+++ b/mod_natura/cotton_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "mod_natura/cotton_plant.json",
   "enabled": true,
   "id": "cotton_plant",
   "plant_name": "Cotton",

--- a/resource/mutations/aurigold_mutation.json
+++ b/resource/mutations/aurigold_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "resource/mutations/aurigold_mutation.json",
   "enabled": true,
   "chance": 0.25,
   "child": "aurigold_plant",

--- a/resource/mutations/diamahlia_mutation.json
+++ b/resource/mutations/diamahlia_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "resource/mutations/diamahlia_mutation.json",
   "enabled": true,
   "chance": 0.25,
   "child": "diamahlia_plant",

--- a/resource/mutations/emeryllis_mutation.json
+++ b/resource/mutations/emeryllis_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "resource/mutations/emeryllis_mutation.json",
   "enabled": true,
   "chance": 1.0,
   "child": "emeryllis_plant",

--- a/resource/mutations/ferranium_mutation.json
+++ b/resource/mutations/ferranium_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "resource/mutations/ferranium_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "ferranium_plant",

--- a/resource/mutations/lapender_mutation.json
+++ b/resource/mutations/lapender_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "resource/mutations/lapender_mutation.json",
   "enabled": true,
   "chance": 0.25,
   "child": "lapender_plant",

--- a/resource/mutations/nitorwart_mutation.json
+++ b/resource/mutations/nitorwart_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "resource/mutations/nitorwart_mutation.json",
   "enabled": true,
   "chance": 0.75,
   "child": "nitorwart_plant",

--- a/resource/mutations/quartzanthemum_mutation.json
+++ b/resource/mutations/quartzanthemum_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "resource/mutations/quartzanthemum_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "quartzanthemum_plant",

--- a/resource/mutations/redstodendron_mutation.json
+++ b/resource/mutations/redstodendron_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "resource/mutations/redstodendron_mutation.json",
   "enabled": true,
   "chance": 1.0,
   "child": "redstodendron_plant",

--- a/resource/plants/aurigold_plant.json
+++ b/resource/plants/aurigold_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "resource/plants/aurigold_plant.json",
   "enabled": true,
   "id": "aurigold_plant",
   "plant_name": "Aurigold",

--- a/resource/plants/diamahlia_plant.json
+++ b/resource/plants/diamahlia_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "resource/plants/diamahlia_plant.json",
   "enabled": true,
   "id": "diamahlia_plant",
   "plant_name": "Diamahlia",

--- a/resource/plants/emeryllis_plant.json
+++ b/resource/plants/emeryllis_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "resource/plants/emeryllis_plant.json",
   "enabled": true,
   "id": "emeryllis_plant",
   "plant_name": "Emeryllis",

--- a/resource/plants/ferranium_plant.json
+++ b/resource/plants/ferranium_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "resource/plants/ferranium_plant.json",
   "enabled": true,
   "id": "ferranium_plant",
   "plant_name": "Ferranium",

--- a/resource/plants/lapender_plant.json
+++ b/resource/plants/lapender_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "resource/plants/lapender_plant.json",
   "enabled": true,
   "id": "lapender_plant",
   "plant_name": "Lapender",

--- a/resource/plants/nitorwart_plant.json
+++ b/resource/plants/nitorwart_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "resource/plants/nitorwart_plant.json",
   "enabled": true,
   "id": "nitorwart_plant",
   "plant_name": "Nitorwart",

--- a/resource/plants/quartzanthemum_plant.json
+++ b/resource/plants/quartzanthemum_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "resource/plants/quartzanthemum_plant.json",
   "enabled": true,
   "id": "quartzanthemum_plant",
   "plant_name": "Quartzanthemum",

--- a/resource/plants/redstodendron_plant.json
+++ b/resource/plants/redstodendron_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "resource/plants/redstodendron_plant.json",
   "enabled": true,
   "id": "redstodendron_plant",
   "plant_name": "Redstodendron",

--- a/resource/soils/gravel_soil.json
+++ b/resource/soils/gravel_soil.json
@@ -1,5 +1,4 @@
 {
-  "path": "resource/soils/gravel_soil.json",
   "enabled": true,
   "id": "gravel_soil",
   "name": "Gravel",

--- a/resource/soils/stone_soil.json
+++ b/resource/soils/stone_soil.json
@@ -1,5 +1,4 @@
 {
-  "path": "resource/soils/stone_soil.json",
   "enabled": true,
   "id": "stone_soil",
   "name": "Stone",

--- a/vanilla/mutations/brown_mushroom_mutation.json
+++ b/vanilla/mutations/brown_mushroom_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "vanilla/mutations/brown_mushroom_mutation.json",
   "enabled": true,
   "chance": 0.50,
   "child": "brown_mushroom_plant",

--- a/vanilla/mutations/cactus_mutation.json
+++ b/vanilla/mutations/cactus_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "vanilla/mutations/cactus_mutation.json",
   "enabled": true,
   "chance": 0.50,
   "child": "cactus_plant",

--- a/vanilla/mutations/carrot_mutation.json
+++ b/vanilla/mutations/carrot_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "vanilla/mutations/carrot_mutation.json",
   "enabled": true,
   "chance": 0.75,
   "child": "carrot_plant",

--- a/vanilla/mutations/melon_mutation.json
+++ b/vanilla/mutations/melon_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "vanilla/mutations/melon_mutation.json",
   "enabled": true,
   "chance": 0.25,
   "child": "melon_plant",

--- a/vanilla/mutations/pumpkin_mutation.json
+++ b/vanilla/mutations/pumpkin_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "vanilla/mutations/pumpkin_mutation.json",
   "enabled": true,
   "chance": 0.25,
   "child": "pumpkin_plant",

--- a/vanilla/mutations/red_mushroom_mutation.json
+++ b/vanilla/mutations/red_mushroom_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "vanilla/mutations/red_mushroom_mutation.json",
   "enabled": true,
   "chance": 0.50,
   "child": "red_mushroom_plant",

--- a/vanilla/mutations/sugarcane_mutation.json
+++ b/vanilla/mutations/sugarcane_mutation.json
@@ -1,5 +1,4 @@
 {
-  "path": "vanilla/mutations/sugarcane_mutation.json",
   "enabled": true,
   "chance": 0.5,
   "child": "sugarcane_plant",

--- a/vanilla/plants/allium_plant.json
+++ b/vanilla/plants/allium_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "vanilla/plants/allium_plant.json",
   "enabled": true,
   "id": "allium_plant",
   "plant_name": "Allium",

--- a/vanilla/plants/beet_plant.json
+++ b/vanilla/plants/beet_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "vanilla/plants/beet_plant.json",
   "enabled": true,
   "id": "beet_plant",
   "plant_name": "Beets",

--- a/vanilla/plants/brown_mushroom_plant.json
+++ b/vanilla/plants/brown_mushroom_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "vanilla/plants/brown_mushroom_plant.json",
   "enabled": true,
   "id": "brown_mushroom_plant",
   "plant_name": "Brown Mushroom",

--- a/vanilla/plants/brownshroom_plant.json
+++ b/vanilla/plants/brownshroom_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "vanilla/plants/brownshroom_plant.json",
   "enabled": true,
   "id": "brownshroom_plant",
   "plant_name": "Brown Mushroom",

--- a/vanilla/plants/cactus_plant.json
+++ b/vanilla/plants/cactus_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "vanilla/plants/cactus_plant.json",
   "enabled": true,
   "id": "cactus_plant",
   "plant_name": "Cactus",

--- a/vanilla/plants/carrot_plant.json
+++ b/vanilla/plants/carrot_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "vanilla/plants/carrot_plant.json",
   "enabled": true,
   "id": "carrot_plant",
   "plant_name": "Carrot",

--- a/vanilla/plants/daisy_plant.json
+++ b/vanilla/plants/daisy_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "vanilla/plants/daisy_plant.json",
   "enabled": true,
   "id": "daisy_plant",
   "plant_name": "Daisy",

--- a/vanilla/plants/dandelion_plant.json
+++ b/vanilla/plants/dandelion_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "vanilla/plants/dandelion_plant.json",
   "enabled": true,
   "id": "dandelion_plant",
   "plant_name": "Dandelion",

--- a/vanilla/plants/melon_plant.json
+++ b/vanilla/plants/melon_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "vanilla/plants/melon_plant.json",
   "enabled": true,
   "id": "melon_plant",
   "plant_name": "Melon",

--- a/vanilla/plants/nether_wart_plant.json
+++ b/vanilla/plants/nether_wart_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "vanilla/plants/nether_wart_plant.json",
   "enabled": true,
   "id": "nether_wart_plant",
   "plant_name": "Nether Wart",

--- a/vanilla/plants/orange_tulip_plant.json
+++ b/vanilla/plants/orange_tulip_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "vanilla/plants/orange_tulip_plant.json",
   "enabled": true,
   "id": "orange_tulip_plant",
   "plant_name": "Orange Tulip",

--- a/vanilla/plants/orchid_plant.json
+++ b/vanilla/plants/orchid_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "vanilla/plants/orchid_plant.json",
   "enabled": true,
   "id": "orchid_plant",
   "plant_name": "Blue Orchid",

--- a/vanilla/plants/pink_tulip_plant.json
+++ b/vanilla/plants/pink_tulip_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "vanilla/plants/pink_tulip_plant.json",
   "enabled": true,
   "id": "pink_tulip_plant",
   "plant_name": "Pink Tulip",

--- a/vanilla/plants/poppy_plant.json
+++ b/vanilla/plants/poppy_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "vanilla/plants/poppy_plant.json",
   "enabled": true,
   "id": "poppy_plant",
   "plant_name": "Poppy",

--- a/vanilla/plants/potato_plant.json
+++ b/vanilla/plants/potato_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "vanilla/plants/potato_plant.json",
   "enabled": true,
   "id": "potato_plant",
   "plant_name": "Potato",

--- a/vanilla/plants/pumpkin_plant.json
+++ b/vanilla/plants/pumpkin_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "vanilla/plants/pumpkin_plant.json",
   "enabled": true,
   "id": "pumpkin_plant",
   "plant_name": "Pumpkin",

--- a/vanilla/plants/red_mushroom_plant.json
+++ b/vanilla/plants/red_mushroom_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "vanilla/plants/red_mushroom_plant.json",
   "enabled": true,
   "id": "red_mushroom_plant",
   "plant_name": "Red Mushroom",

--- a/vanilla/plants/red_tulip_plant.json
+++ b/vanilla/plants/red_tulip_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "vanilla/plants/red_tulip_plant.json",
   "enabled": true,
   "id": "red_tulip_plant",
   "plant_name": "Red Tulip",

--- a/vanilla/plants/redshroom_plant.json
+++ b/vanilla/plants/redshroom_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "vanilla/plants/redshroom_plant.json",
   "enabled": true,
   "id": "redshroom_plant",
   "plant_name": "Red Mushroom",

--- a/vanilla/plants/sugarcane_plant.json
+++ b/vanilla/plants/sugarcane_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "vanilla/plants/sugarcane_plant.json",
   "enabled": true,
   "id": "sugarcane_plant",
   "plant_name": "Sugarcane",

--- a/vanilla/plants/weed_plant.json
+++ b/vanilla/plants/weed_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "vanilla/plants/weed_plant.json",
   "enabled": true,
   "id": "weed_plant",
   "plant_name": "Weed",

--- a/vanilla/plants/wheat_plant.json
+++ b/vanilla/plants/wheat_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "vanilla/plants/wheat_plant.json",
   "enabled": true,
   "id": "wheat_plant",
   "plant_name": "Wheat",

--- a/vanilla/plants/white_tulip_plant.json
+++ b/vanilla/plants/white_tulip_plant.json
@@ -1,5 +1,4 @@
 {
-  "path": "vanilla/plants/white_tulip_plant.json",
   "enabled": true,
   "id": "white_tulip_plant",
   "plant_name": "White Tulip",

--- a/vanilla/soils/farmland_soil.json
+++ b/vanilla/soils/farmland_soil.json
@@ -1,5 +1,4 @@
 {
-  "path": "vanilla/soils/farmland_soil.json",
   "enabled": true,
   "id": "farmland_soil",
   "name": "Farmland",

--- a/vanilla/soils/grass_soil.json
+++ b/vanilla/soils/grass_soil.json
@@ -1,5 +1,4 @@
 {
-  "path": "vanilla/soils/grass_soil.json",
   "enabled": true,
   "id": "grass_soil",
   "name": "Grass",

--- a/vanilla/soils/mycelium_soil.json
+++ b/vanilla/soils/mycelium_soil.json
@@ -1,5 +1,4 @@
 {
-  "path": "vanilla/soils/mycelium_soil.json",
   "enabled": true,
   "id": "mycelium_soil",
   "name": "Mycelium",

--- a/vanilla/soils/sand_soil.json
+++ b/vanilla/soils/sand_soil.json
@@ -1,5 +1,4 @@
 {
-  "path": "vanilla/soils/sand_soil.json",
   "enabled": true,
   "id": "sand_soil",
   "name": "Sand",

--- a/vanilla/soils/soul_sand_soil.json
+++ b/vanilla/soils/soul_sand_soil.json
@@ -1,5 +1,4 @@
 {
-  "path": "vanilla/soils/soul_sand_soil.json",
   "enabled": true,
   "id": "soul_sand_soil",
   "name": "Soul Sand",


### PR DESCRIPTION
Since the path variable is directly overwritten after GSON reading, it
is superfluous in the configuration files.

When merging, **don't forget the AgriCore PR**!