### PR TITLE
Added mod resource crops

### DIFF
--- a/resource/mutations/cuprosia_mutation.json
+++ b/resource/mutations/cuprosia_mutation.json
@@ -1,0 +1,8 @@
+{
+  "path": "resource/mutations/cuprosia_mutation.json",
+  "enabled": true,
+  "chance": 0.5,
+  "child": "cuprosia_plant",
+  "parent1": "redstodendron_plant",
+  "parent2": "red_tulip_plant"
+}

--- a/resource/mutations/jaslumine_mutation.json
+++ b/resource/mutations/jaslumine_mutation.json
@@ -1,0 +1,8 @@
+{
+  "path": "resource/mutations/jaslumine_mutation.json",
+  "enabled": true,
+  "chance": 0.5,
+  "child": "jaslumine_plant",
+  "parent1": "ferranium_plant",
+  "parent2": "wheat_plant"
+}

--- a/resource/mutations/niccissus_mutation.json
+++ b/resource/mutations/niccissus_mutation.json
@@ -1,0 +1,8 @@
+{
+  "path": "resource/mutations/niccissus_mutation.json",
+  "enabled": true,
+  "chance": 0.25,
+  "child": "niccissus_plant",
+  "parent1": "aurigold_plant",
+  "parent2": "dandelion_plant"
+}

--- a/resource/mutations/petinia_mutation.json
+++ b/resource/mutations/petinia_mutation.json
@@ -1,0 +1,8 @@
+{
+  "path": "resource/mutations/petinia_mutation.json",
+  "enabled": true,
+  "chance": 0.5,
+  "child": "petinia_plant",
+  "parent1": "lapender_plant",
+  "parent2": "daisy_plant"
+}

--- a/resource/mutations/plombean_mutation.json
+++ b/resource/mutations/plombean_mutation.json
@@ -1,0 +1,8 @@
+{
+  "path": "resource/mutations/plombean_mutation.json",
+  "enabled": true,
+  "chance": 0.25,
+  "child": "plombean_plant",
+  "parent1": "ferranium_plant",
+  "parent2": "potato_plant"
+}

--- a/resource/mutations/silverweed_mutation.json
+++ b/resource/mutations/silverweed_mutation.json
@@ -1,0 +1,8 @@
+{
+  "path": "resource/mutations/silverweed_mutation.json",
+  "enabled": true,
+  "chance": 0.25,
+  "child": "silverweed_plant",
+  "parent1": "aurigold_plant",
+  "parent2": "allium_plant"
+}

--- a/resource/plants/cuprosia_plant.json
+++ b/resource/plants/cuprosia_plant.json
@@ -1,0 +1,77 @@
+{
+  "path": "resource/plants/cuprosia_plant.json",
+  "enabled": true,
+  "id": "cuprosia_plant",
+  "plant_name": "Cuprosia",
+  "seed_name": "Cuprosia Seeds",
+  "seed_items": [],
+  "description": {
+    "translations": {},
+    "default": "A versatile plant."
+  },
+  "growth_chance": 0.9,
+  "growth_bonus": 0.025,
+  "bonemeal": false,
+  "tier": 1,
+  "weedable": false,
+  "aggressive": false,
+  "spread_chance": 0.1,
+  "spawn_chance": 0.0,
+  "grass_drop_chance": 0.0,
+  "seed_drop_chance": 1.0,
+  "seed_drop_bonus": 0.0,
+  "products": {
+    "products": [
+      {
+        "min": 1,
+        "max": 2,
+        "chance": 0.95,
+        "required": true,
+        "item": "thermalfoundation:material",
+        "meta": 192,
+        "tags": "",
+        "ignoreMeta": false,
+        "ignoreTags": [],
+        "useOreDict": true
+      }
+    ]
+  },
+  "requirement": {
+    "min_light": 10,
+    "max_light": 16,
+    "soils": [
+      "gravel_soil"
+    ],
+    "conditions": [
+      {
+        "amount": 1,
+        "min_x": 0,
+        "min_y": -2,
+        "min_z": 0,
+        "max_x": 0,
+        "max_y": -2,
+        "max_z": 0,
+        "item": "thermalfoundation:ore",
+        "meta": 0,
+        "tags": "",
+        "ignoreMeta": true,
+        "ignoreTags": [],
+        "useOreDict": true
+      }
+    ]
+  },
+  "texture": {
+    "render_type": "hash",
+    "seed_texture": "agricraft:items/seed_cuprosia",
+    "plant_textures": [
+      "agricraft:blocks/crop_cuprosia1",
+      "agricraft:blocks/crop_cuprosia1",
+      "agricraft:blocks/crop_cuprosia1",
+      "agricraft:blocks/crop_cuprosia2",
+      "agricraft:blocks/crop_cuprosia2",
+      "agricraft:blocks/crop_cuprosia2",
+      "agricraft:blocks/crop_cuprosia3",
+      "agricraft:blocks/crop_cuprosia4"
+    ]
+  }
+}

--- a/resource/plants/jaslumine_plant.json
+++ b/resource/plants/jaslumine_plant.json
@@ -1,0 +1,77 @@
+{
+  "path": "resource/plants/jaslumine_plant.json",
+  "enabled": true,
+  "id": "jaslumine_plant",
+  "plant_name": "Jaslumine",
+  "seed_name": "Jaslumine Seeds",
+  "seed_items": [],
+  "description": {
+    "translations": {},
+    "default": "A foiled plant."
+  },
+  "growth_chance": 0.9,
+  "growth_bonus": 0.025,
+  "bonemeal": false,
+  "tier": 1,
+  "weedable": false,
+  "aggressive": false,
+  "spread_chance": 0.1,
+  "spawn_chance": 0.0,
+  "grass_drop_chance": 0.0,
+  "seed_drop_chance": 1.0,
+  "seed_drop_bonus": 0.0,
+  "products": {
+    "products": [
+      {
+        "min": 1,
+        "max": 2,
+        "chance": 0.95,
+        "required": true,
+        "item": "thermalfoundation:material",
+        "meta": 196,
+        "tags": "",
+        "ignoreMeta": false,
+        "ignoreTags": [],
+        "useOreDict": true
+      }
+    ]
+  },
+  "requirement": {
+    "min_light": 10,
+    "max_light": 16,
+    "soils": [
+      "gravel_soil"
+    ],
+    "conditions": [
+      {
+        "amount": 1,
+        "min_x": 0,
+        "min_y": -2,
+        "min_z": 0,
+        "max_x": 0,
+        "max_y": -2,
+        "max_z": 0,
+        "item": "thermalfoundation:ore",
+        "meta": 4,
+        "tags": "",
+        "ignoreMeta": true,
+        "ignoreTags": [],
+        "useOreDict": true
+      }
+    ]
+  },
+  "texture": {
+    "render_type": "hash",
+    "seed_texture": "agricraft:items/seed_jaslumine",
+    "plant_textures": [
+      "agricraft:blocks/crop_jaslumine1",
+      "agricraft:blocks/crop_jaslumine1",
+      "agricraft:blocks/crop_jaslumine1",
+      "agricraft:blocks/crop_jaslumine2",
+      "agricraft:blocks/crop_jaslumine2",
+      "agricraft:blocks/crop_jaslumine2",
+      "agricraft:blocks/crop_jaslumine3",
+      "agricraft:blocks/crop_jaslumine4"
+    ]
+  }
+}

--- a/resource/plants/niccissus_plant.json
+++ b/resource/plants/niccissus_plant.json
@@ -1,0 +1,77 @@
+{
+  "path": "resource/plants/niccissus_plant.json",
+  "enabled": true,
+  "id": "niccissus_plant",
+  "plant_name": "Niccissus",
+  "seed_name": "Niccissus Seeds",
+  "seed_items": [],
+  "description": {
+    "translations": {},
+    "default": "Self Absorbed..."
+  },
+  "growth_chance": 0.8,
+  "growth_bonus": 0.025,
+  "bonemeal": false,
+  "tier": 1,
+  "weedable": false,
+  "aggressive": false,
+  "spread_chance": 0.1,
+  "spawn_chance": 0.0,
+  "grass_drop_chance": 0.0,
+  "seed_drop_chance": 1.0,
+  "seed_drop_bonus": 0.0,
+  "products": {
+    "products": [
+      {
+        "min": 1,
+        "max": 1,
+        "chance": 0.8,
+        "required": true,
+        "item": "thermalfoundation:material",
+        "meta": 197,
+        "tags": "",
+        "ignoreMeta": false,
+        "ignoreTags": [],
+        "useOreDict": true
+      }
+    ]
+  },
+  "requirement": {
+    "min_light": 10,
+    "max_light": 16,
+    "soils": [
+      "gravel_soil"
+    ],
+    "conditions": [
+      {
+        "amount": 1,
+        "min_x": 0,
+        "min_y": -2,
+        "min_z": 0,
+        "max_x": 0,
+        "max_y": -2,
+        "max_z": 0,
+        "item": "thermalfoundation:ore",
+        "meta": 5,
+        "tags": "",
+        "ignoreMeta": true,
+        "ignoreTags": [],
+        "useOreDict": true
+      }
+    ]
+  },
+  "texture": {
+    "render_type": "hash",
+    "seed_texture": "agricraft:items/seed_niccissus",
+    "plant_textures": [
+      "agricraft:blocks/crop_niccissus1",
+      "agricraft:blocks/crop_niccissus1",
+      "agricraft:blocks/crop_niccissus2",
+      "agricraft:blocks/crop_niccissus2",
+      "agricraft:blocks/crop_niccissus2",
+      "agricraft:blocks/crop_niccissus3",
+      "agricraft:blocks/crop_niccissus3",
+      "agricraft:blocks/crop_niccissus4"
+    ]
+  }
+}

--- a/resource/plants/petinia_plant.json
+++ b/resource/plants/petinia_plant.json
@@ -1,0 +1,77 @@
+{
+  "path": "resource/plants/petinia_plant.json",
+  "enabled": true,
+  "id": "petinia_plant",
+  "plant_name": "Petinia",
+  "seed_name": "Petinia Seeds",
+  "seed_items": [],
+  "description": {
+    "translations": {},
+    "default": "A standard plant."
+  },
+  "growth_chance": 0.9,
+  "growth_bonus": 0.025,
+  "bonemeal": false,
+  "tier": 1,
+  "weedable": false,
+  "aggressive": false,
+  "spread_chance": 0.1,
+  "spawn_chance": 0.0,
+  "grass_drop_chance": 0.0,
+  "seed_drop_chance": 1.0,
+  "seed_drop_bonus": 0.0,
+  "products": {
+    "products": [
+      {
+        "min": 1,
+        "max": 2,
+        "chance": 0.95,
+        "required": true,
+        "item": "thermalfoundation:material",
+        "meta": 193,
+        "tags": "",
+        "ignoreMeta": false,
+        "ignoreTags": [],
+        "useOreDict": true
+      }
+    ]
+  },
+  "requirement": {
+    "min_light": 10,
+    "max_light": 16,
+    "soils": [
+      "gravel_soil"
+    ],
+    "conditions": [
+      {
+        "amount": 1,
+        "min_x": 0,
+        "min_y": -2,
+        "min_z": 0,
+        "max_x": 0,
+        "max_y": -2,
+        "max_z": 0,
+        "item": "thermalfoundation:ore",
+        "meta": 1,
+        "tags": "",
+        "ignoreMeta": true,
+        "ignoreTags": [],
+        "useOreDict": true
+      }
+    ]
+  },
+  "texture": {
+    "render_type": "hash",
+    "seed_texture": "agricraft:items/seed_petinia",
+    "plant_textures": [
+      "agricraft:blocks/crop_petinia1",
+      "agricraft:blocks/crop_petinia1",
+      "agricraft:blocks/crop_petinia1",
+      "agricraft:blocks/crop_petinia2",
+      "agricraft:blocks/crop_petinia2",
+      "agricraft:blocks/crop_petinia2",
+      "agricraft:blocks/crop_petinia3",
+      "agricraft:blocks/crop_petinia4"
+    ]
+  }
+}

--- a/resource/plants/plombean_plant.json
+++ b/resource/plants/plombean_plant.json
@@ -1,0 +1,77 @@
+{
+  "path": "resource/plants/plombean_plant.json",
+  "enabled": true,
+  "id": "plombean_plant",
+  "plant_name": "Plombean",
+  "seed_name": "Plombean Seeds",
+  "seed_items": [],
+  "description": {
+    "translations": {},
+    "default": "Handle with gloves!"
+  },
+  "growth_chance": 0.8,
+  "growth_bonus": 0.025,
+  "bonemeal": false,
+  "tier": 1,
+  "weedable": false,
+  "aggressive": false,
+  "spread_chance": 0.1,
+  "spawn_chance": 0.0,
+  "grass_drop_chance": 0.0,
+  "seed_drop_chance": 1.0,
+  "seed_drop_bonus": 0.0,
+  "products": {
+    "products": [
+      {
+        "min": 1,
+        "max": 1,
+        "chance": 0.8,
+        "required": true,
+        "item": "thermalfoundation:material",
+        "meta": 195,
+        "tags": "",
+        "ignoreMeta": false,
+        "ignoreTags": [],
+        "useOreDict": true
+      }
+    ]
+  },
+  "requirement": {
+    "min_light": 10,
+    "max_light": 16,
+    "soils": [
+      "gravel_soil"
+    ],
+    "conditions": [
+      {
+        "amount": 1,
+        "min_x": 0,
+        "min_y": -2,
+        "min_z": 0,
+        "max_x": 0,
+        "max_y": -2,
+        "max_z": 0,
+        "item": "thermalfoundation:ore",
+        "meta": 3,
+        "tags": "",
+        "ignoreMeta": true,
+        "ignoreTags": [],
+        "useOreDict": true
+      }
+    ]
+  },
+  "texture": {
+    "render_type": "hash",
+    "seed_texture": "agricraft:items/seed_plombean",
+    "plant_textures": [
+      "agricraft:blocks/crop_plombean1",
+      "agricraft:blocks/crop_plombean1",
+      "agricraft:blocks/crop_plombean2",
+      "agricraft:blocks/crop_plombean2",
+      "agricraft:blocks/crop_plombean2",
+      "agricraft:blocks/crop_plombean3",
+      "agricraft:blocks/crop_plombean3",
+      "agricraft:blocks/crop_plombean4"
+    ]
+  }
+}

--- a/resource/plants/silverweed_plant.json
+++ b/resource/plants/silverweed_plant.json
@@ -1,0 +1,77 @@
+{
+  "path": "resource/plants/silverweed_plant.json",
+  "enabled": true,
+  "id": "silverweed_plant",
+  "plant_name": "Silverweed",
+  "seed_name": "Silverweed Seeds",
+  "seed_items": [],
+  "description": {
+    "translations": {},
+    "default": "A silver surprise."
+  },
+  "growth_chance": 0.8,
+  "growth_bonus": 0.025,
+  "bonemeal": false,
+  "tier": 1,
+  "weedable": false,
+  "aggressive": false,
+  "spread_chance": 0.1,
+  "spawn_chance": 0.0,
+  "grass_drop_chance": 0.0,
+  "seed_drop_chance": 1.0,
+  "seed_drop_bonus": 0.0,
+  "products": {
+    "products": [
+      {
+        "min": 1,
+        "max": 1,
+        "chance": 0.8,
+        "required": true,
+        "item": "thermalfoundation:material",
+        "meta": 194,
+        "tags": "",
+        "ignoreMeta": false,
+        "ignoreTags": [],
+        "useOreDict": true
+      }
+    ]
+  },
+  "requirement": {
+    "min_light": 10,
+    "max_light": 16,
+    "soils": [
+      "gravel_soil"
+    ],
+    "conditions": [
+      {
+        "amount": 1,
+        "min_x": 0,
+        "min_y": -2,
+        "min_z": 0,
+        "max_x": 0,
+        "max_y": -2,
+        "max_z": 0,
+        "item": "thermalfoundation:ore",
+        "meta": 2,
+        "tags": "",
+        "ignoreMeta": true,
+        "ignoreTags": [],
+        "useOreDict": true
+      }
+    ]
+  },
+  "texture": {
+    "render_type": "hash",
+    "seed_texture": "agricraft:items/seed_silverweed",
+    "plant_textures": [
+      "agricraft:blocks/crop_silverweed1",
+      "agricraft:blocks/crop_silverweed1",
+      "agricraft:blocks/crop_silverweed2",
+      "agricraft:blocks/crop_silverweed2",
+      "agricraft:blocks/crop_silverweed2",
+      "agricraft:blocks/crop_silverweed3",
+      "agricraft:blocks/crop_silverweed3",
+      "agricraft:blocks/crop_silverweed4"
+    ]
+  }
+}


### PR DESCRIPTION
I made jsons for (most of) the standard mod ores, defaulting to the Thermal Foundation versions of them. I dunno how yall handle ore dictionary plant products, but if you tell me how I can fix that.

Also you might want to update your documentation. 

> The seeds for the the different dye plants can't be obtained without cheating.

is not technically true, as you can get the dye plant seeds by mutations from existing seeds. Which is what I did in my own world to get the mod ores.