### PR TITLE
Remove localization from json definitions

### DIFF
--- a/resource/plants/aurigold_plant.json
+++ b/resource/plants/aurigold_plant.json
@@ -3,19 +3,10 @@
   "version": "1.16.4",
   "enabled": true,
   "id": "resource:aurigold_plant",
-  "plant_name": {
-    "default": "Aurigold",
-    "translations": {}
-  },
-  "seed_name": {
-    "default": "Aurigold Seeds",
-    "translations": {}
-  },
+  "plant_lang_key": "agricraft.plant.aurigold.name",
+  "seed_lang_key": "agricraft.plant.aurigold.seed",
+  "desc_lang_key": "agricraft.plant.aurigold.desc",
   "seed_items": [],
-  "description": {
-    "default": "A golden delight.",
-    "translations": {}
-  },
   "stages": 8,
   "harvestStage": 4,
   "growth_chance": 0.8,

--- a/resource/plants/cuprosia_plant.json
+++ b/resource/plants/cuprosia_plant.json
@@ -3,19 +3,10 @@
   "version": "1.16.4",
   "enabled": true,
   "id": "resource:cuprosia_plant",
-  "plant_name": {
-    "default": "Cuprosia",
-    "translations": {}
-  },
-  "seed_name": {
-    "default": "Cuprosia Seeds",
-    "translations": {}
-  },
+  "plant_lang_key": "agricraft.plant.cuprosia.name",
+  "seed_lang_key": "agricraft.plant.cuprosia.seed",
+  "desc_lang_key": "agricraft.plant.cuprosia.desc",
   "seed_items": [],
-  "description": {
-    "default": "Known as the engineer\u0027s delight, this plant produces a substance of incredible utility.",
-    "translations": {}
-  },
   "stages": 8,
   "harvestStage": 4,
   "growth_chance": 0.9,

--- a/resource/plants/diamahlia_plant.json
+++ b/resource/plants/diamahlia_plant.json
@@ -3,19 +3,10 @@
   "version": "1.16.4",
   "enabled": true,
   "id": "resource:diamahlia_plant",
-  "plant_name": {
-    "default": "Diamahlia",
-    "translations": {}
-  },
-  "seed_name": {
-    "default": "Diamahlia Seeds",
-    "translations": {}
-  },
+  "plant_lang_key": "agricraft.plant.diamahlia.name",
+  "seed_lang_key": "agricraft.plant.diamahlia.seed",
+  "desc_lang_key": "agricraft.plant.diamahlia.desc",
   "seed_items": [],
-  "description": {
-    "default": "A rarity by any measure.",
-    "translations": {}
-  },
   "stages": 8,
   "harvestStage": 4,
   "growth_chance": 0.75,

--- a/resource/plants/emeryllis_plant.json
+++ b/resource/plants/emeryllis_plant.json
@@ -3,19 +3,10 @@
   "version": "1.16.4",
   "enabled": true,
   "id": "resource:emeryllis_plant",
-  "plant_name": {
-    "default": "Emeryllis",
-    "translations": {}
-  },
-  "seed_name": {
-    "default": "Emeryllis Seeds",
-    "translations": {}
-  },
+  "plant_lang_key": "agricraft.plant.emeryllis.name",
+  "seed_lang_key": "agricraft.plant.emeryllis.seed",
+  "desc_lang_key": "agricraft.plant.emeryllis.desc",
   "seed_items": [],
-  "description": {
-    "default": "A truely green gem.",
-    "translations": {}
-  },
   "stages": 8,
   "harvestStage": 4,
   "growth_chance": 0.9,

--- a/resource/plants/ferranium_plant.json
+++ b/resource/plants/ferranium_plant.json
@@ -3,19 +3,10 @@
   "version": "1.16.4",
   "enabled": true,
   "id": "resource:ferranium_plant",
-  "plant_name": {
-    "default": "Ferranium",
-    "translations": {}
-  },
-  "seed_name": {
-    "default": "Ferranum Seeds",
-    "translations": {}
-  },
+  "plant_lang_key": "agricraft.plant.ferranium.name",
+  "seed_lang_key": "agricraft.plant.ferranium.seed",
+  "desc_lang_key": "agricraft.plant.ferranium.desc",
   "seed_items": [],
-  "description": {
-    "default": "A strong plant.",
-    "translations": {}
-  },
   "stages": 8,
   "harvestStage": 4,
   "growth_chance": 0.9,

--- a/resource/plants/jaslumine_plant.json
+++ b/resource/plants/jaslumine_plant.json
@@ -3,19 +3,10 @@
   "version": "1.16.4",
   "enabled": true,
   "id": "resource:jaslumine_plant",
-  "plant_name": {
-    "default": "Jaslumine",
-    "translations": {}
-  },
-  "seed_name": {
-    "default": "Jaslumine Seeds",
-    "translations": {}
-  },
+  "plant_lang_key": "agricraft.plant.jaslumine.name",
+  "seed_lang_key": "agricraft.plant.jaslumine.seed",
+  "desc_lang_key": "agricraft.plant.jaslumine.desc",
   "seed_items": [],
-  "description": {
-    "default": "Jaslumine to some, Jaluminium to me. Shines like silver, but not all that valuable of a plant.",
-    "translations": {}
-  },
   "stages": 8,
   "harvestStage": 4,
   "growth_chance": 0.9,

--- a/resource/plants/lapender_plant.json
+++ b/resource/plants/lapender_plant.json
@@ -3,19 +3,10 @@
   "version": "1.16.4",
   "enabled": true,
   "id": "resource:lapender_plant",
-  "plant_name": {
-    "default": "Lapender",
-    "translations": {}
-  },
-  "seed_name": {
-    "default": "Lapender Seeds",
-    "translations": {}
-  },
+  "plant_lang_key": "agricraft.plant.lapender.name",
+  "seed_lang_key": "agricraft.plant.lapender.seed",
+  "desc_lang_key": "agricraft.plant.lapender.desc",
   "seed_items": [],
-  "description": {
-    "default": "A regal plant.",
-    "translations": {}
-  },
   "stages": 8,
   "harvestStage": 4,
   "growth_chance": 0.9,

--- a/resource/plants/niccissus_plant.json
+++ b/resource/plants/niccissus_plant.json
@@ -3,19 +3,10 @@
   "version": "1.16.4",
   "enabled": true,
   "id": "resource:niccissus_plant",
-  "plant_name": {
-    "default": "Niccissus",
-    "translations": {}
-  },
-  "seed_name": {
-    "default": "Niccissus Seeds",
-    "translations": {}
-  },
+  "plant_lang_key": "agricraft.plant.niccissus.name",
+  "seed_lang_key": "agricraft.plant.niccissus.seed",
+  "desc_lang_key": "agricraft.plant.niccissus.desc",
   "seed_items": [],
-  "description": {
-    "default": "While there is much debate over which is the best plant, we can all agree that the Niccissus plant is by far the most self-absorbed.",
-    "translations": {}
-  },
   "stages": 8,
   "harvestStage": 4,
   "growth_chance": 0.9,

--- a/resource/plants/nitorwart_plant.json
+++ b/resource/plants/nitorwart_plant.json
@@ -3,19 +3,10 @@
   "version": "1.16.4",
   "enabled": true,
   "id": "resource:nitorwart_plant",
-  "plant_name": {
-    "default": "Nitorwart",
-    "translations": {}
-  },
-  "seed_name": {
-    "default": "Burning Spores",
-    "translations": {}
-  },
+  "plant_lang_key": "agricraft.plant.nitorwart.name",
+  "seed_lang_key": "agricraft.plant.nitorwart.seed",
+  "desc_lang_key": "agricraft.plant.nitorwart.desc",
   "seed_items": [],
-  "description": {
-    "default": "It sure seems to like to glow.",
-    "translations": {}
-  },
   "stages": 8,
   "harvestStage": 4,
   "growth_chance": 0.9,
@@ -70,7 +61,7 @@
     ]
   },
   "callbacks": [
-	"agricraft:brightness"
+    "agricraft:brightness"
   ],
   "texture": {
     "render_type": "hash",

--- a/resource/plants/osmonium_plant.json
+++ b/resource/plants/osmonium_plant.json
@@ -3,19 +3,10 @@
   "version": "1.16.4",
   "enabled": true,
   "id": "resource:osmonium_plant",
-  "plant_name": {
-    "default": "Osmonium",
-    "translations": {}
-  },
-  "seed_name": {
-    "default": "Osmonium Seeds",
-    "translations": {}
-  },
+  "plant_lang_key": "agricraft.plant.osmonium.name",
+  "seed_lang_key": "agricraft.plant.osmonium.seed",
+  "desc_lang_key": "agricraft.plant.osmonium.desc",
   "seed_items": [],
-  "description": {
-    "default": "An unusually rare plant, thought to originate from outer space.",
-    "translations": {}
-  },
   "stages": 8,
   "harvestStage": 4,
   "growth_chance": 0.9,

--- a/resource/plants/petinia_plant.json
+++ b/resource/plants/petinia_plant.json
@@ -3,19 +3,10 @@
   "version": "1.16.4",
   "enabled": true,
   "id": "resource:petinia_plant",
-  "plant_name": {
-    "default": "Petinia",
-    "translations": {}
-  },
-  "seed_name": {
-    "default": "Petinia Seeds",
-    "translations": {}
-  },
+  "plant_lang_key": "agricraft.plant.petinia.name",
+  "seed_lang_key": "agricraft.plant.petinia.seed",
+  "desc_lang_key": "agricraft.plant.petinia.desc",
   "seed_items": [],
-  "description": {
-    "default": "A distant cousin of the familiar petunia flower, this plant produces a substance frequently used to plate metal cans.",
-    "translations": {}
-  },
   "stages": 8,
   "harvestStage": 4,
   "growth_chance": 0.9,

--- a/resource/plants/platiolus_plant.json
+++ b/resource/plants/platiolus_plant.json
@@ -3,19 +3,10 @@
   "version": "1.16.4",
   "enabled": true,
   "id": "resource:platiolus_plant",
-  "plant_name": {
-    "default": "Platiolus",
-    "translations": {}
-  },
-  "seed_name": {
-    "default": "Platiolus Seeds",
-    "translations": {}
-  },
+  "plant_lang_key": "agricraft.plant.platiolus.name",
+  "seed_lang_key": "agricraft.plant.platiolus.seed",
+  "desc_lang_key": "agricraft.plant.platiolus.desc",
   "seed_items": [],
-  "description": {
-    "default": "The unquestioned king among the metal-bearing plants, this plant has a gleam to it that puts even the aurigold flower to shame.",
-    "translations": {}
-  },
   "stages": 8,
   "harvestStage": 4,
   "growth_chance": 0.9,

--- a/resource/plants/plombean_plant.json
+++ b/resource/plants/plombean_plant.json
@@ -3,19 +3,10 @@
   "version": "1.16.4",
   "enabled": true,
   "id": "resource:plombean_plant",
-  "plant_name": {
-    "default": "Plombean",
-    "translations": {}
-  },
-  "seed_name": {
-    "default": "Plombean Seeds",
-    "translations": {}
-  },
+  "plant_lang_key": "agricraft.plant.plombean.name",
+  "seed_lang_key": "agricraft.plant.plombean.seed",
+  "desc_lang_key": "agricraft.plant.plombean.desc",
   "seed_items": [],
-  "description": {
-    "default": "In ancient times this plant was thought to bear a lifegiving fruit. Nowadays we know better.",
-    "translations": {}
-  },
   "stages": 8,
   "harvestStage": 4,
   "growth_chance": 0.9,

--- a/resource/plants/quartzanthemum_plant.json
+++ b/resource/plants/quartzanthemum_plant.json
@@ -3,19 +3,10 @@
   "version": "1.16.4",
   "enabled": true,
   "id": "resource:quartzanthemum_plant",
-  "plant_name": {
-    "default": "Quartzanthemum",
-    "translations": {}
-  },
-  "seed_name": {
-    "default": "Crystalline Seeds",
-    "translations": {}
-  },
+  "plant_lang_key": "agricraft.plant.quartzanthemum.name",
+  "seed_lang_key": "agricraft.plant.quartzanthemum.seed",
+  "desc_lang_key": "agricraft.plant.quartzanthemum.desc",
   "seed_items": [],
-  "description": {
-    "default": "A suprisingly crystalline plant.",
-    "translations": {}
-  },
   "stages": 8,
   "harvestStage": 4,
   "growth_chance": 0.9,

--- a/resource/plants/redstodendron_plant.json
+++ b/resource/plants/redstodendron_plant.json
@@ -3,19 +3,10 @@
   "version": "1.16.4",
   "enabled": true,
   "id": "resource:redstodendron_plant",
-  "plant_name": {
-    "default": "Redstodendron",
-    "translations": {}
-  },
-  "seed_name": {
-    "default": "Red Seeds",
-    "translations": {}
-  },
+  "plant_lang_key": "agricraft.plant.redstodendron.name",
+  "seed_lang_key": "agricraft.plant.redstodendron.seed",
+  "desc_lang_key": "agricraft.plant.redstodendron.desc",
   "seed_items": [],
-  "description": {
-    "default": "Much more complex than the average red algea.",
-    "translations": {}
-  },
   "stages": 8,
   "harvestStage": 4,
   "growth_chance": 0.9,

--- a/resource/soils/gravel_soil.json
+++ b/resource/soils/gravel_soil.json
@@ -3,10 +3,7 @@
   "version": "1.16.4",
   "enabled": true,
   "id": "gravel_soil",
-  "name": {
-    "default": "Gravel",
-    "translations": {}
-  },
+  "lang_key": "agricraft.soil.gravel.name",
   "varients": [
     {
       "type": "block",

--- a/resource/soils/stone_soil.json
+++ b/resource/soils/stone_soil.json
@@ -3,10 +3,7 @@
   "version": "1.16.4",
   "enabled": true,
   "id": "stone_soil",
-  "name": {
-    "default": "Stone",
-    "translations": {}
-  },
+  "lang_key": "agricraft.soil.stone.name",
   "varients": [
     {
       "type": "block",

--- a/vanilla/plants/allium_plant.json
+++ b/vanilla/plants/allium_plant.json
@@ -3,19 +3,10 @@
   "version": "1.16.4",
   "enabled": true,
   "id": "vanilla:allium_plant",
-  "plant_name": {
-    "default": "Allium",
-    "translations": {}
-  },
-  "seed_name": {
-    "default": "Allium Seeds",
-    "translations": {}
-  },
+  "plant_lang_key": "agricraft.plant.allium.name",
+  "seed_lang_key": "agricraft.plant.allium.seed",
+  "desc_lang_key": "agricraft.plant.allium.desc",
   "seed_items": [],
-  "description": {
-    "default": "From the family of plants including the garlic, onion, and chive this plant produces a beautiful umbel consisting of many small purple blooms.",
-    "translations": {}
-  },
   "stages": 8,
   "harvestStage": 4,
   "growth_chance": 0.75,

--- a/vanilla/plants/beet_root_plant.json
+++ b/vanilla/plants/beet_root_plant.json
@@ -3,14 +3,9 @@
   "version": "1.16.4",
   "enabled": true,
   "id": "vanilla:beet_root_plant",
-  "plant_name": {
-    "default": "Beets",
-    "translations": {}
-  },
-  "seed_name": {
-    "default": "Beet Seeds",
-    "translations": {}
-  },
+  "plant_lang_key": "agricraft.plant.beet_root.name",
+  "seed_lang_key": "agricraft.plant.beet_root.seed",
+  "desc_lang_key": "agricraft.plant.beet_root.desc",
   "seed_items": [
     {
       "overridePlanting": false,
@@ -23,10 +18,6 @@
       ]
     }
   ],
-  "description": {
-    "default": "Beet. It\u0027s what\u0027s for dinner.",
-    "translations": {}
-  },
   "stages": 8,
   "harvestStage": 4,
   "growth_chance": 1.0,

--- a/vanilla/plants/brown_mushroom_plant.json
+++ b/vanilla/plants/brown_mushroom_plant.json
@@ -3,14 +3,9 @@
   "version": "1.16.4",
   "enabled": true,
   "id": "vanilla:brown_mushroom_plant",
-  "plant_name": {
-    "default": "Brown Mushroom",
-    "translations": {}
-  },
-  "seed_name": {
-    "default": "Brown Mushroom Spores",
-    "translations": {}
-  },
+  "plant_lang_key": "agricraft.plant.brown_mushroom.name",
+  "seed_lang_key": "agricraft.plant.brown_mushroom.seed",
+  "desc_lang_key": "agricraft.plant.brown_mushroom.desc",
   "seed_items": [
     {
       "overridePlanting": false,
@@ -23,10 +18,6 @@
       ]
     }
   ],
-  "description": {
-    "default": "A simple decomposer.",
-    "translations": {}
-  },
   "stages": 8,
   "harvestStage": 4,
   "growth_chance": 0.9,

--- a/vanilla/plants/cactus_plant.json
+++ b/vanilla/plants/cactus_plant.json
@@ -3,14 +3,9 @@
   "version": "1.16.4",
   "enabled": true,
   "id": "vanilla:cactus_plant",
-  "plant_name": {
-    "default": "Cactus",
-    "translations": {}
-  },
-  "seed_name": {
-    "default": "Cactus Seeds",
-    "translations": {}
-  },
+  "plant_lang_key": "agricraft.plant.cactus.name",
+  "seed_lang_key": "agricraft.plant.cactus.seed",
+  "desc_lang_key": "agricraft.plant.cactus.desc",
   "seed_items": [
     {
       "overridePlanting": false,
@@ -23,10 +18,6 @@
       ]
     }
   ],
-  "description": {
-    "default": "A very prickly plant.",
-    "translations": {}
-  },
   "stages": 8,
   "harvestStage": 4,
   "growth_chance": 0.9,

--- a/vanilla/plants/carrot_plant.json
+++ b/vanilla/plants/carrot_plant.json
@@ -3,14 +3,9 @@
   "version": "1.16.4",
   "enabled": true,
   "id": "vanilla:carrot_plant",
-  "plant_name": {
-    "default": "Carrot",
-    "translations": {}
-  },
-  "seed_name": {
-    "default": "Carrot Seeds",
-    "translations": {}
-  },
+  "plant_lang_key": "agricraft.plant.carrot.name",
+  "seed_lang_key": "agricraft.plant.carrot.seed",
+  "desc_lang_key": "agricraft.plant.carrot.desc",
   "seed_items": [
     {
       "overridePlanting": false,
@@ -23,10 +18,6 @@
       ]
     }
   ],
-  "description": {
-    "default": "Rabbit attractant.",
-    "translations": {}
-  },
   "stages": 8,
   "harvestStage": 4,
   "growth_chance": 0.9,

--- a/vanilla/plants/daisy_plant.json
+++ b/vanilla/plants/daisy_plant.json
@@ -3,19 +3,10 @@
   "version": "1.16.4",
   "enabled": true,
   "id": "vanilla:daisy_plant",
-  "plant_name": {
-    "default": "Daisy",
-    "translations": {}
-  },
-  "seed_name": {
-    "default": "Daisy Seeds",
-    "translations": {}
-  },
+  "plant_lang_key": "agricraft.plant.daisy.name",
+  "seed_lang_key": "agricraft.plant.daisy.seed",
+  "desc_lang_key": "agricraft.plant.daisy.desc",
   "seed_items": [],
-  "description": {
-    "default": "A rarity by any measure.",
-    "translations": {}
-  },
   "stages": 8,
   "harvestStage": 4,
   "growth_chance": 0.75,

--- a/vanilla/plants/dandelion_plant.json
+++ b/vanilla/plants/dandelion_plant.json
@@ -3,19 +3,10 @@
   "version": "1.16.4",
   "enabled": true,
   "id": "vanilla:dandelion_plant",
-  "plant_name": {
-    "default": "Dandelion",
-    "translations": {}
-  },
-  "seed_name": {
-    "default": "Dandelion Seeds",
-    "translations": {}
-  },
+  "plant_lang_key": "agricraft.plant.dandelion.name",
+  "seed_lang_key": "agricraft.plant.dandelion.seed",
+  "desc_lang_key": "agricraft.plant.dandelion.desc",
   "seed_items": [],
-  "description": {
-    "default": "While colloquially considered a weed, this yellow-flowering plant is one of unspoken value. Having a deep-rooting taproot, the plant brings up nutrients from lower levels of soil, making it a good companion plant for shallow rooting plants.",
-    "translations": {}
-  },
   "stages": 8,
   "harvestStage": 4,
   "growth_chance": 0.75,

--- a/vanilla/plants/melon_plant.json
+++ b/vanilla/plants/melon_plant.json
@@ -3,14 +3,9 @@
   "version": "1.16.4",
   "enabled": true,
   "id": "vanilla:melon_plant",
-  "plant_name": {
-    "default": "Melon",
-    "translations": {}
-  },
-  "seed_name": {
-    "default": "Melon Seeds",
-    "translations": {}
-  },
+  "plant_lang_key": "agricraft.plant.melon.name",
+  "seed_lang_key": "agricraft.plant.melon.seed",
+  "desc_lang_key": "agricraft.plant.melon.desc",
   "seed_items": [
     {
       "overridePlanting": false,
@@ -23,10 +18,6 @@
       ]
     }
   ],
-  "description": {
-    "default": "Sweet \u0026 Juicy.",
-    "translations": {}
-  },
   "stages": 8,
   "harvestStage": 4,
   "growth_chance": 0.65,

--- a/vanilla/plants/nether_wart_plant.json
+++ b/vanilla/plants/nether_wart_plant.json
@@ -3,14 +3,9 @@
   "version": "1.16.4",
   "enabled": true,
   "id": "vanilla:nether_wart_plant",
-  "plant_name": {
-    "default": "Nether Wart",
-    "translations": {}
-  },
-  "seed_name": {
-    "default": "Nether Spores",
-    "translations": {}
-  },
+  "plant_lang_key": "agricraft.plant.nether_wart.name",
+  "seed_lang_key": "agricraft.plant.nether_wart.seed",
+  "desc_lang_key": "agricraft.plant.nether_wart.desc",
   "seed_items": [
     {
       "overridePlanting": false,
@@ -23,10 +18,6 @@
       ]
     }
   ],
-  "description": {
-    "default": "An oddity from the nether, said to have somewhat mystical properties. The fungus appears to have a strong aptitude for heat, yet oddly cannot withstand the burning of the sun. Its fruit makes a covetable prize for the aspiring young brewer.",
-    "translations": {}
-  },
   "stages": 8,
   "harvestStage": 4,
   "growth_chance": 0.9,

--- a/vanilla/plants/orange_tulip_plant.json
+++ b/vanilla/plants/orange_tulip_plant.json
@@ -3,19 +3,10 @@
   "version": "1.16.4",
   "enabled": true,
   "id": "vanilla:orange_tulip_plant",
-  "plant_name": {
-    "default": "Orange Tulip",
-    "translations": {}
-  },
-  "seed_name": {
-    "default": "Orange Tulip Seeds",
-    "translations": {}
-  },
+  "plant_lang_key": "agricraft.plant.orange_tulip.name",
+  "seed_lang_key": "agricraft.plant.orange_tulip.seed",
+  "desc_lang_key": "agricraft.plant.orange_tulip.desc",
   "seed_items": [],
-  "description": {
-    "default": "A rarity by any measure.",
-    "translations": {}
-  },
   "stages": 8,
   "harvestStage": 4,
   "growth_chance": 0.75,

--- a/vanilla/plants/orchid_plant.json
+++ b/vanilla/plants/orchid_plant.json
@@ -3,19 +3,10 @@
   "version": "1.16.4",
   "enabled": true,
   "id": "vanilla:orchid_plant",
-  "plant_name": {
-    "default": "Blue Orchid",
-    "translations": {}
-  },
-  "seed_name": {
-    "default": "Blue Orchid Seeds",
-    "translations": {}
-  },
+  "plant_lang_key": "agricraft.plant.orchid.name",
+  "seed_lang_key": "agricraft.plant.orchid.seed",
+  "desc_lang_key": "agricraft.plant.orchid.desc",
   "seed_items": [],
-  "description": {
-    "default": "A rarity by any measure.",
-    "translations": {}
-  },
   "stages": 8,
   "harvestStage": 4,
   "growth_chance": 0.75,

--- a/vanilla/plants/pink_tulip_plant.json
+++ b/vanilla/plants/pink_tulip_plant.json
@@ -3,19 +3,10 @@
   "version": "1.16.4",
   "enabled": true,
   "id": "vanilla:pink_tulip_plant",
-  "plant_name": {
-    "default": "Pink Tulip",
-    "translations": {}
-  },
-  "seed_name": {
-    "default": "Pink Tulip Seeds",
-    "translations": {}
-  },
+  "plant_lang_key": "agricraft.plant.pink_tulip.name",
+  "seed_lang_key": "agricraft.plant.pink_tulip.seed",
+  "desc_lang_key": "agricraft.plant.pink_tulip.desc",
   "seed_items": [],
-  "description": {
-    "default": "A pink varient of the perrenial tulip plant. The plant is valued mostly for its distinctive blooms.",
-    "translations": {}
-  },
   "stages": 8,
   "harvestStage": 4,
   "growth_chance": 0.75,

--- a/vanilla/plants/poppy_plant.json
+++ b/vanilla/plants/poppy_plant.json
@@ -3,19 +3,10 @@
   "version": "1.16.4",
   "enabled": true,
   "id": "vanilla:poppy_plant",
-  "plant_name": {
-    "default": "Poppy",
-    "translations": {}
-  },
-  "seed_name": {
-    "default": "Poppy Seeds",
-    "translations": {}
-  },
+  "plant_lang_key": "agricraft.plant.poppy.name",
+  "seed_lang_key": "agricraft.plant.poppy.seed",
+  "desc_lang_key": "agricraft.plant.poppy.desc",
   "seed_items": [],
-  "description": {
-    "default": "Producing colorful blooms, this plant has gained a reputation for certain medicinal uses. A better use, perhaps, this plant produces seeds that go well with baked goods, particularly for lemon-flavored ones.",
-    "translations": {}
-  },
   "stages": 8,
   "harvestStage": 4,
   "growth_chance": 0.75,

--- a/vanilla/plants/potato_plant.json
+++ b/vanilla/plants/potato_plant.json
@@ -3,14 +3,9 @@
   "version": "1.16.4",
   "enabled": true,
   "id": "vanilla:potato_plant",
-  "plant_name": {
-    "default": "Potato",
-    "translations": {}
-  },
-  "seed_name": {
-    "default": "Potato Seeds",
-    "translations": {}
-  },
+  "plant_lang_key": "agricraft.plant.potato.name",
+  "seed_lang_key": "agricraft.plant.potato.seed",
+  "desc_lang_key": "agricraft.plant.potato.desc",
   "seed_items": [
     {
       "overridePlanting": false,
@@ -23,10 +18,6 @@
       ]
     }
   ],
-  "description": {
-    "default": "Po-ta-toes! Boil them, mash them, stick them in a stew.",
-    "translations": {}
-  },
   "stages": 8,
   "harvestStage": 4,
   "growth_chance": 0.9,

--- a/vanilla/plants/pumpkin_plant.json
+++ b/vanilla/plants/pumpkin_plant.json
@@ -3,14 +3,9 @@
   "version": "1.16.4",
   "enabled": true,
   "id": "vanilla:pumpkin_plant",
-  "plant_name": {
-    "default": "Pumpkin",
-    "translations": {}
-  },
-  "seed_name": {
-    "default": "Pumpkin Seeds",
-    "translations": {}
-  },
+  "plant_lang_key": "agricraft.plant.pumpkin.name",
+  "seed_lang_key": "agricraft.plant.pumpkin.seed",
+  "desc_lang_key": "agricraft.plant.pumpkin.desc",
   "seed_items": [
     {
       "overridePlanting": false,
@@ -23,10 +18,6 @@
       ]
     }
   ],
-  "description": {
-    "default": "If I eat enough of these will I turn orange?",
-    "translations": {}
-  },
   "stages": 8,
   "harvestStage": 4,
   "growth_chance": 0.75,

--- a/vanilla/plants/red_mushroom_plant.json
+++ b/vanilla/plants/red_mushroom_plant.json
@@ -3,14 +3,9 @@
   "version": "1.16.4",
   "enabled": true,
   "id": "vanilla:red_mushroom_plant",
-  "plant_name": {
-    "default": "Red Mushroom",
-    "translations": {}
-  },
-  "seed_name": {
-    "default": "Red Mushroom Spores",
-    "translations": {}
-  },
+  "plant_lang_key": "agricraft.plant.red_mushroom.name",
+  "seed_lang_key": "agricraft.plant.red_mushroom.seed",
+  "desc_lang_key": "agricraft.plant.red_mushroom.desc",
   "seed_items": [
     {
       "overridePlanting": false,
@@ -23,12 +18,6 @@
       ]
     }
   ],
-  "description": {
-    "default": "Badger, badger, badger.",
-    "translations": {
-      "en_US": "Shrooms, ever so trippy."
-    }
-  },
   "stages": 8,
   "harvestStage": 4,
   "growth_chance": 0.9,

--- a/vanilla/plants/red_tulip_plant.json
+++ b/vanilla/plants/red_tulip_plant.json
@@ -3,19 +3,10 @@
   "version": "1.16.4",
   "enabled": true,
   "id": "vanilla:red_tulip_plant",
-  "plant_name": {
-    "default": "Red Tulip",
-    "translations": {}
-  },
-  "seed_name": {
-    "default": "Red Tulip Seeds",
-    "translations": {}
-  },
+  "plant_lang_key": "agricraft.plant.red_tulip.name",
+  "seed_lang_key": "agricraft.plant.red_tulip.seed",
+  "desc_lang_key": "agricraft.plant.red_tulip.desc",
   "seed_items": [],
-  "description": {
-    "default": "A vibrant red varient of the perrenial tulip plant. The plant is valued mostly for its distinctive blooms.",
-    "translations": {}
-  },
   "stages": 8,
   "harvestStage": 4,
   "growth_chance": 0.75,

--- a/vanilla/plants/sugarcane_plant.json
+++ b/vanilla/plants/sugarcane_plant.json
@@ -3,14 +3,9 @@
   "version": "1.16.4",
   "enabled": true,
   "id": "vanilla:sugarcane_plant",
-  "plant_name": {
-    "default": "Sugarcane",
-    "translations": {}
-  },
-  "seed_name": {
-    "default": "Sugarcane Seeds",
-    "translations": {}
-  },
+  "plant_lang_key": "agricraft.plant.sugarcane.name",
+  "seed_lang_key": "agricraft.plant.sugarcane.seed",
+  "desc_lang_key": "agricraft.plant.sugarcane.desc",
   "seed_items": [
     {
       "overridePlanting": false,
@@ -23,13 +18,6 @@
       ]
     }
   ],
-  "description": {
-    "default": "A good source of sugar.",
-    "translations": {
-      "en_us": "High in fructose, a healthy part of your daily breakfast.",
-      "es_es": "Mucho azucar."
-    }
-  },
   "stages": 8,
   "harvestStage": 4,
   "growth_chance": 0.9,

--- a/vanilla/plants/wheat_plant.json
+++ b/vanilla/plants/wheat_plant.json
@@ -3,14 +3,9 @@
   "version": "1.16.4",
   "enabled": true,
   "id": "vanilla:wheat_plant",
-  "plant_name": {
-    "default": "Wheat",
-    "translations": {}
-  },
-  "seed_name": {
-    "default": "Wheat Seeds",
-    "translations": {}
-  },
+  "plant_lang_key": "agricraft.plant.wheat.name",
+  "seed_lang_key": "agricraft.plant.wheat.seed",
+  "desc_lang_key": "agricraft.plant.wheat.desc",
   "seed_items": [
     {
       "overridePlanting": false,
@@ -23,10 +18,6 @@
       ]
     }
   ],
-  "description": {
-    "default": "The cornerstone of the Agriculutural Revolution.",
-    "translations": {}
-  },
   "stages": 8,
   "harvestStage": 4,
   "growth_chance": 0.9,

--- a/vanilla/plants/white_tulip_plant.json
+++ b/vanilla/plants/white_tulip_plant.json
@@ -3,19 +3,10 @@
   "version": "1.16.4",
   "enabled": true,
   "id": "vanilla:white_tulip_plant",
-  "plant_name": {
-    "default": "White Tulip",
-    "translations": {}
-  },
-  "seed_name": {
-    "default": "White Tulip Seeds",
-    "translations": {}
-  },
+  "plant_lang_key": "agricraft.plant.white_tulip.name",
+  "seed_lang_key": "agricraft.plant.white_tulip.seed",
+  "desc_lang_key": "agricraft.plant.white_tulip.desc",
   "seed_items": [],
-  "description": {
-    "default": "A snow-white varient of the perrenial tulip plant. The plant is valued mostly for its distinctive blooms.",
-    "translations": {}
-  },
   "stages": 8,
   "harvestStage": 4,
   "growth_chance": 0.75,

--- a/vanilla/soils/farmland_soil.json
+++ b/vanilla/soils/farmland_soil.json
@@ -3,10 +3,7 @@
   "version": "1.16.4",
   "enabled": true,
   "id": "farmland_soil",
-  "name": {
-    "default": "Farmland",
-    "translations": {}
-  },
+  "lang_key": "agricraft.soil.farmland.name",
   "varients": [
     {
       "type": "block",

--- a/vanilla/soils/grass_soil.json
+++ b/vanilla/soils/grass_soil.json
@@ -3,10 +3,7 @@
   "version": "1.16.4",
   "enabled": true,
   "id": "grass_soil",
-  "name": {
-    "default": "Grass",
-    "translations": {}
-  },
+  "lang_key": "agricraft.soil.grass.name",
   "varients": [
     {
       "type": "block",

--- a/vanilla/soils/mycelium_soil.json
+++ b/vanilla/soils/mycelium_soil.json
@@ -3,10 +3,7 @@
   "version": "1.16.4",
   "enabled": true,
   "id": "mycelium_soil",
-  "name": {
-    "default": "Mycelium",
-    "translations": {}
-  },
+  "lang_key": "agricraft.soil.mycelium.name",
   "varients": [
     {
       "type": "block",

--- a/vanilla/soils/sand_soil.json
+++ b/vanilla/soils/sand_soil.json
@@ -3,10 +3,7 @@
   "version": "1.16.4",
   "enabled": true,
   "id": "sand_soil",
-  "name": {
-    "default": "Sand",
-    "translations": {}
-  },
+  "lang_key": "agricraft.soil.sand.name",
   "varients": [
     {
       "type": "block",

--- a/vanilla/soils/soul_sand_soil.json
+++ b/vanilla/soils/soul_sand_soil.json
@@ -3,10 +3,7 @@
   "version": "1.16.4",
   "enabled": true,
   "id": "soul_sand_soil",
-  "name": {
-    "default": "Soul Sand",
-    "translations": {}
-  },
+  "lang_key": "agricraft.soil.soul_sand.name",
   "varients": [
     {
       "type": "block",

--- a/vanilla/weeds/weed_weed.json
+++ b/vanilla/weeds/weed_weed.json
@@ -3,14 +3,8 @@
   "version": "1.16.4",
   "enabled": true,
   "id": "agricraft:weed_weed",
-  "weed_name": {
-    "default": "weeds",
-    "translations": {}
-  },
-  "description": {
-    "default": "A nuisance for sure.",
-    "translations": {}
-  },
+  "weed_lang_key": "agricraft.weed.weed.name",
+  "desc_lang_key": "agricraft.weed.weed.desc",
   "stages": 8,
   "spawn_chance": 0.25,
   "growth_chance": 0.9,


### PR DESCRIPTION
Removed localisation from AgriCore, as Minecraft supports this perfectly with their Resource Packs.

Resource Packs are needed anyway for textures and models, therefore it makes sense to move localisation to the Resource Packs as well.