### PR TITLE
Update bamboo_plant.json

### DIFF
--- a/vanilla/plants/bamboo_plant.json
+++ b/vanilla/plants/bamboo_plant.json
@@ -15,7 +15,7 @@
     {
       "overridePlanting": false,
       "type": "item",
-      "object": "minecraft:sugar_cane",
+      "object": "minecraft:bamboo",
       "useTag": false,
       "data": "",
       "ignoredData": [


### PR DESCRIPTION
This fixes an issue where planting sugar cane on crop sticks gives bamboo seeds instead of sugar cane seeds.